### PR TITLE
pow: always return minimum difficulty in shadow fork mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
                procps bison python3 python3-pip python3-setuptools python3-wheel
           apt-get install -y ${{ matrix.packages }}
           python3 -m pip install setuptools==70.3.0 --upgrade
-          python3 -m pip install "lief==0.16.5"
+          python3 -m pip install "lief==0.12.3"
 
       - name: Post install
         if: ${{ matrix.postinstall }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
                procps bison python3 python3-pip python3-setuptools python3-wheel
           apt-get install -y ${{ matrix.packages }}
           python3 -m pip install setuptools==70.3.0 --upgrade
-          python3 -m pip install lief
+          python3 -m pip install "lief==0.16.5"
 
       - name: Post install
         if: ${{ matrix.postinstall }}

--- a/contrib/docker/testnet-node/Dockerfile
+++ b/contrib/docker/testnet-node/Dockerfile
@@ -1,11 +1,13 @@
-# Dockerfile for Dogecoin Testnet Node
+# Dockerfile for Dogecoin Node (supports mainnet and testnet via NETWORK env var)
 # Multi-stage build: compiles dogecoind in container for library compatibility
 #
 # Build from repo root:
-#   docker build -f contrib/docker/testnet-node/Dockerfile -t dogecoin-testnet .
+#   docker build -f contrib/docker/testnet-node/Dockerfile -t dogecoin:latest-shadowfork .
 #
-# Run:
-#   docker run -v testnet-data:/data -p 44555:44555 -p 44556:44556 dogecoin-testnet
+# Run (testnet, default):
+#   docker run -v testnet-data:/data -p 44555:44555 -p 44556:44556 dogecoin:latest-shadowfork
+# Run (mainnet):
+#   docker run -e NETWORK=mainnet -v mainnet-data:/data -p 22555:22555 -p 22556:22556 dogecoin:latest-shadowfork
 
 # =============================================================================
 # Stage 1: Build dogecoind from source
@@ -93,15 +95,15 @@ RUN chmod 755 /entrypoint.sh
 ENV DOGECOIN_DATA=/data
 ENV DOGECOIN_CONF=/config/dogecoin.conf
 
-# Expose testnet ports (P2P: 44556, RPC: 44555)
-EXPOSE 44555 44556
+# Expose both mainnet (22555/22556) and testnet (44555/44556) ports
+EXPOSE 22555 22556 44555 44556
 
-# Health check via RPC
+# Health check via RPC (port depends on NETWORK: mainnet=22555, testnet=44555)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD curl -sf --user "${RPC_USER:-test}:${RPC_PASS:-test}" \
         -d '{"jsonrpc":"1.0","method":"getblockchaininfo","params":[]}' \
         -H 'content-type: text/plain;' \
-        http://127.0.0.1:44555/ || exit 1
+        http://127.0.0.1:${RPC_PORT:-44555}/ || exit 1
 
 USER dogecoin
 WORKDIR /home/dogecoin

--- a/contrib/docker/testnet-node/scripts/entrypoint.sh
+++ b/contrib/docker/testnet-node/scripts/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-# Entrypoint for Dogecoin testnet node
+# Entrypoint for Dogecoin node
+# Supports both mainnet and testnet via NETWORK env var
 # Supports both built-in binaries (multi-stage) and mounted binaries
 
 # Find dogecoind binary
@@ -18,21 +19,25 @@ else
     exit 1
 fi
 
+NETWORK="${NETWORK:-testnet}"
 DATA_DIR="${DOGECOIN_DATA:-/data}"
 CONF_FILE="${DOGECOIN_CONF:-/config/dogecoin.conf}"
 
-echo "=== Dogecoin Testnet Node ==="
+echo "=== Dogecoin Node ($NETWORK) ==="
 echo "Binary: $DOGECOIND"
 echo "Data: $DATA_DIR"
 echo "Config: $CONF_FILE"
 
-# Ensure testnet3 subdirectory exists (dogecoind creates it, but we verify)
-mkdir -p "$DATA_DIR/testnet3"
-
 # Build command
 CMD="$DOGECOIND"
 CMD="$CMD -datadir=$DATA_DIR"
-CMD="$CMD -testnet"  # Must be on CLI - conf file testnet=1 doesn't set datadir path correctly
+
+if [ "$NETWORK" = "testnet" ]; then
+    # Ensure testnet3 subdirectory exists (dogecoind creates it, but we verify)
+    mkdir -p "$DATA_DIR/testnet3"
+    CMD="$CMD -testnet"
+fi
+
 CMD="$CMD -printtoconsole"  # Log to stdout for docker logs
 CMD="$CMD -rpcbind=0.0.0.0"  # Must be on CLI for docker port forwarding
 CMD="$CMD -rpcallowip=0.0.0.0/0"  # Allow RPC from any IP (docker network)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -547,6 +547,12 @@ public:
         consensus.fPowNoRetargeting = true;
         consensus.fPowAllowMinDifficultyBlocks = true;
 
+        // Use simplified (constant) block rewards. The old random reward
+        // formula overflows when halvings >= 20 (height ~2M+) because
+        // (1000000 >> halvings) - 1 goes negative, causing
+        // boost::uniform_int(1, maxReward) to assert min <= max.
+        consensus.fSimplifiedRewards = true;
+
         // Allow legacy blocks (block type enforcement is bypassed via
         // fShadowForkMode in ContextualCheckBlockHeader)
         consensus.fAllowLegacyBlocks = true;

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -32,6 +32,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#ifdef __APPLE__
+#include <sys/endian.h>
+#endif
 
 #if defined(USE_SSE2) && !defined(USE_SSE2_ALWAYS)
 #ifdef _MSC_VER
@@ -43,7 +46,7 @@
 #endif
 #endif
 
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 static inline uint32_t be32dec(const void *pp)
 {
 	const uint8_t *p = (uint8_t const *)pp;

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -32,9 +32,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#ifdef __APPLE__
-#include <sys/endian.h>
-#endif
 
 #if defined(USE_SSE2) && !defined(USE_SSE2_ALWAYS)
 #ifdef _MSC_VER
@@ -46,7 +43,7 @@
 #endif
 #endif
 
-#if !defined(__FreeBSD__) && !defined(__APPLE__)
+#if !defined(__FreeBSD__)
 static inline uint32_t be32dec(const void *pp)
 {
 	const uint8_t *p = (uint8_t const *)pp;

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -7,6 +7,9 @@
 #define BITCOIN_CRYPTO_SCRYPT_H
 #include <stdlib.h>
 #include <stdint.h>
+#ifdef __APPLE__
+#include <sys/endian.h>
+#endif
 
 #if defined(HAVE_CONFIG_H)
 #include "bitcoin-config.h" // for USE_SSE2
@@ -36,7 +39,7 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 static inline uint32_t le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -7,9 +7,6 @@
 #define BITCOIN_CRYPTO_SCRYPT_H
 #include <stdlib.h>
 #include <stdint.h>
-#ifdef __APPLE__
-#include <sys/endian.h>
-#endif
 
 #if defined(HAVE_CONFIG_H)
 #include "bitcoin-config.h" // for USE_SSE2
@@ -39,7 +36,7 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
-#if !defined(__FreeBSD__) && !defined(__APPLE__)
+#if !defined(__FreeBSD__)
 static inline uint32_t le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -37,6 +37,10 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     if (pindexLast == NULL)
         return nProofOfWorkLimit;
 
+    // Shadow fork / regtest: always minimum difficulty (instant mining)
+    if (params.fPowNoRetargeting)
+        return nProofOfWorkLimit;
+
     // Dogecoin: Special rules for minimum difficulty blocks with Digishield
     if (AllowDigishieldMinDifficultyForBlock(pindexLast, pblock, params))
     {


### PR DESCRIPTION
## Summary
- Short-circuit `GetNextWorkRequired()` to return `powLimit` when `fPowNoRetargeting` is true
- Shadow fork nodes were inheriting testnet difficulty, making mining take 15-50+ seconds per block
- Enable simplified rewards in shadow fork to fix overflow at high halvings
- Docker image now supports both mainnet and testnet via `NETWORK` env var
- Fix scrypt compilation on macOS (endian header conflicts)

## What changed

### pow.cpp
2-line addition: when `params.fPowNoRetargeting` is true (set by both shadow fork and regtest chain params), return minimum difficulty immediately instead of falling through to `CalculateDogecoinNextWorkRequired()`.

### chainparams.cpp
Enable `fSimplifiedRewards` for shadow fork mode. The old random reward formula overflows when halvings >= 20 (height ~2M+) because `(1000000 >> halvings) - 1` goes negative, causing `boost::uniform_int(1, maxReward)` to assert `min <= max`.

### Docker (Dockerfile + entrypoint.sh)
Accept `NETWORK=mainnet` or `NETWORK=testnet` (default) to select which chain to run. Exposes ports for both networks.

### scrypt.cpp / scrypt.h
Include `<sys/endian.h>` on Apple platforms and skip local `be32dec`/`le32dec` definitions that conflict with macOS system headers.

## Test plan
- [x] Rebuilt and started shadow fork node from testnet data
- [x] Mined 100 blocks in 0.29s (previously took minutes)
- [x] Difficulty confirmed at `4.656e-10` (minimum)
- [x] Safe for regtest: `pindexLast->nBits` is already `powLimit` there, so behavior is unchanged
- [x] Shadow fork survives past halving overflow height with simplified rewards
- [x] Docker image builds and runs in both mainnet and testnet mode
- [x] scrypt.cpp compiles on macOS without endian conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)