### PR TITLE
feat: add regtest as valid shadowforkchain source

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -525,9 +525,13 @@ public:
     void InitFromSourceChain() {
         std::string sourceChain = GetArg("-shadowforkchain", "main");
 
-        const CChainParams* pSourceParams = (sourceChain == "test")
-            ? static_cast<const CChainParams*>(&testNetParams)
-            : static_cast<const CChainParams*>(&mainParams);
+        const CChainParams* pSourceParams;
+        if (sourceChain == "test")
+            pSourceParams = static_cast<const CChainParams*>(&testNetParams);
+        else if (sourceChain == "regtest")
+            pSourceParams = static_cast<const CChainParams*>(&regTestParams);
+        else
+            pSourceParams = static_cast<const CChainParams*>(&mainParams);
 
         // Use the source chain's genesis block so that:
         // 1. CheckBlockIndex passes (genesis hash matches consensus)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -910,8 +910,8 @@ bool AppInitParameterInteraction()
         }
 
         std::string sourceChain = GetArg("-shadowforkchain", "main");
-        if (sourceChain != "main" && sourceChain != "test") {
-            return InitError(_("Shadow fork source chain must be 'main' or 'test'."));
+        if (sourceChain != "main" && sourceChain != "test" && sourceChain != "regtest") {
+            return InitError(_("Shadow fork source chain must be 'main', 'test', or 'regtest'."));
         }
 
         int64_t nMaturity = GetArg("-shadowforkmaturity", 1);


### PR DESCRIPTION
## Summary
- Adds `regtest` as a valid value for the `shadowforkchain` configuration parameter
- Previously only `main` and `test` were accepted; now the shadow fork node can use regtest chain data as its source
- Enables local E2E testing of shadow fork orchestrator against regtest nodes

## Changes
- `src/chainparams.cpp`: Add `regtest` branch to source chain selection logic
- `src/init.cpp`: Update validation to accept `regtest` alongside `main` and `test`

## Test plan
- [x] Local regtest shadow fork: started source regtest node, created shadow fork with `shadowforkchain=regtest`, verified genesis block matches and blocks can be mined
- [x] Orchestrator E2E: created fork with `fork_height=10` from source at height 20, verified `invalidateblock` rollback works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)