### PR TITLE
perf: add shadow fork runtime fast paths

### DIFF
--- a/contrib/docker/testnet-node/Dockerfile
+++ b/contrib/docker/testnet-node/Dockerfile
@@ -99,7 +99,8 @@ RUN chmod 755 /entrypoint.sh
 
 # Default environment
 ENV DOGECOIN_DATA=/data
-ENV DOGECOIN_CONF=/config/dogecoin.conf
+# Leave DOGECOIN_CONF unset by default so the entrypoint can choose a
+# network-appropriate config path unless the caller explicitly overrides it.
 
 # Expose both mainnet (22555/22556) and testnet (44555/44556) ports
 EXPOSE 22555 22556 44555 44556

--- a/contrib/docker/testnet-node/Dockerfile
+++ b/contrib/docker/testnet-node/Dockerfile
@@ -15,10 +15,14 @@
 FROM ubuntu:22.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
+ARG UBUNTU_APT_MIRROR=
 
 # Install build dependencies
 # Note: libboost-all-dev ensures complete Boost installation with all linking deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN if [ -n "$UBUNTU_APT_MIRROR" ]; then \
+        sed -i "s|http://archive.ubuntu.com/ubuntu|$UBUNTU_APT_MIRROR|g" /etc/apt/sources.list; \
+    fi \
+    && apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libtool \
     autotools-dev \
@@ -38,9 +42,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /dogecoin
 COPY . .
 
+ARG STRIP_BINARIES=1
+
 # Build dogecoind with wallet support (needed for generatetoaddress mining).
 # --with-incompatible-bdb: accept system BDB 5.3 (matches libdb5.3++-dev above).
-# Strip binaries to reduce image size.
+# Strip binaries by default to reduce image size.
 RUN ./autogen.sh \
     && ./configure \
         --disable-tests \
@@ -48,7 +54,7 @@ RUN ./autogen.sh \
         --without-gui \
         --with-incompatible-bdb \
     && make -j$(nproc) \
-    && strip src/dogecoind src/dogecoin-cli
+    && if [ "$STRIP_BINARIES" = "1" ]; then strip src/dogecoind src/dogecoin-cli; fi
 
 # =============================================================================
 # Stage 2: Runtime image (slim Debian for smaller footprint)

--- a/contrib/docker/testnet-node/Dockerfile
+++ b/contrib/docker/testnet-node/Dockerfile
@@ -106,10 +106,11 @@ EXPOSE 22555 22556 44555 44556
 
 # Health check via RPC (port depends on NETWORK: mainnet=22555, testnet=44555)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -sf --user "${RPC_USER:-test}:${RPC_PASS:-test}" \
-        -d '{"jsonrpc":"1.0","method":"getblockchaininfo","params":[]}' \
-        -H 'content-type: text/plain;' \
-        http://127.0.0.1:${RPC_PORT:-44555}/ || exit 1
+    CMD RPC_PORT="${RPC_PORT:-$(if [ "${NETWORK:-testnet}" = "mainnet" ]; then echo 22555; else echo 44555; fi)}" \
+        && curl -sf --user "${RPC_USER:-shadowfork}:${RPC_PASS:-shadowfork_testnet_password}" \
+            -d '{"jsonrpc":"1.0","method":"getblockchaininfo","params":[]}' \
+            -H 'content-type: text/plain;' \
+            "http://127.0.0.1:${RPC_PORT}/" || exit 1
 
 USER dogecoin
 WORKDIR /home/dogecoin

--- a/contrib/docker/testnet-node/scripts/entrypoint.sh
+++ b/contrib/docker/testnet-node/scripts/entrypoint.sh
@@ -21,7 +21,13 @@ fi
 
 NETWORK="${NETWORK:-testnet}"
 DATA_DIR="${DOGECOIN_DATA:-/data}"
-CONF_FILE="${DOGECOIN_CONF:-/config/dogecoin.conf}"
+if [ -n "${DOGECOIN_CONF:-}" ]; then
+    CONF_FILE="$DOGECOIN_CONF"
+elif [ "$NETWORK" = "testnet" ]; then
+    CONF_FILE="/config/dogecoin.conf"
+else
+    CONF_FILE="/config/dogecoin-mainnet.conf"
+fi
 
 echo "=== Dogecoin Node ($NETWORK) ==="
 echo "Binary: $DOGECOIND"

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -533,10 +533,10 @@ public:
         else
             pSourceParams = static_cast<const CChainParams*>(&mainParams);
 
-        // Use the source chain's message start bytes so that the block
-        // file reader can find blocks in the copied .dat files (they are
-        // serialized with the source chain's magic bytes).
-        memcpy(pchMessageStart, pSourceParams->MessageStart(), sizeof(pchMessageStart));
+        // Keep the shadowfork P2P message start isolated while teaching the
+        // block/undo file reader to look for the source chain's on-disk magic.
+        memcpy(pchDiskMagic, pSourceParams->MessageStart(), sizeof(pchDiskMagic));
+        fHasDiskMagic = true;
 
         // Use the source chain's genesis block so that:
         // 1. CheckBlockIndex passes (genesis hash matches consensus)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -533,6 +533,11 @@ public:
         else
             pSourceParams = static_cast<const CChainParams*>(&mainParams);
 
+        // Use the source chain's message start bytes so that the block
+        // file reader can find blocks in the copied .dat files (they are
+        // serialized with the source chain's magic bytes).
+        memcpy(pchMessageStart, pSourceParams->MessageStart(), sizeof(pchMessageStart));
+
         // Use the source chain's genesis block so that:
         // 1. CheckBlockIndex passes (genesis hash matches consensus)
         // 2. Source blocks can chain from genesis (hashPrevBlock is in mapBlockIndex)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -62,6 +62,7 @@ public:
     }
 
     const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
+    const CMessageHeader::MessageStartChars& DiskMagic() const { return fHasDiskMagic ? pchDiskMagic : pchMessageStart; }
     int GetDefaultPort() const { return nDefaultPort; }
 
     const CBlock& GenesisBlock() const { return genesis; }
@@ -83,11 +84,12 @@ public:
     const ChainTxData& TxData() const { return chainTxData; }
 
 protected:
-    CChainParams() {}
+    CChainParams() : fHasDiskMagic(false) {}
 
     Consensus::Params consensus;
     Consensus::Params *pConsensusRoot; // Binary search tree root
     CMessageHeader::MessageStartChars pchMessageStart;
+    CMessageHeader::MessageStartChars pchDiskMagic;
     int nDefaultPort;
     uint64_t nPruneAfterHeight;
     std::vector<CDNSSeedData> vSeeds;
@@ -101,6 +103,7 @@ protected:
     bool fMineBlocksOnDemand;
     CCheckpointData checkpointData;
     ChainTxData chainTxData;
+    bool fHasDiskMagic;
 };
 
 /**

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -43,7 +43,9 @@
 #endif
 #endif
 
-#if !defined(__FreeBSD__)
+#if defined(__APPLE__)
+/* macOS SDK 26+ provides be32dec/be32enc via sys/endian.h (already included from scrypt.h) */
+#elif !defined(__FreeBSD__)
 static inline uint32_t be32dec(const void *pp)
 {
 	const uint8_t *p = (uint8_t const *)pp;

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -36,7 +36,9 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
-#if !defined(__FreeBSD__)
+#if defined(__APPLE__)
+#include <sys/endian.h>
+#elif !defined(__FreeBSD__)
 static inline uint32_t le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;

--- a/src/dogecoin.cpp
+++ b/src/dogecoin.cpp
@@ -15,6 +15,7 @@
 
 int static generateMTRandom(unsigned int s, int range)
 {
+    if (range < 1) return 0;
     boost::mt19937 gen(s);
     boost::uniform_int<> dist(1, range);
     return dist(gen);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -477,6 +477,12 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-shadowfork=<height>", _("Enable shadow fork mode, forking from the specified block height"));
         strUsage += HelpMessageOpt("-shadowforkchain=<chain>", _("Source chain to fork from: main or test (default: main)"));
         strUsage += HelpMessageOpt("-shadowforkmaturity=<n>", strprintf(_("Coinbase maturity for shadow fork (default: %d)"), 1));
+        strUsage += HelpMessageOpt("-shadowforkfastblockindexcandidates", _("In shadow fork mode, populate block index candidates from the active tip only during startup (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforkdeferchainstateflush", _("In shadow fork mode, defer automatic IF_NEEDED/PERIODIC chainstate flushes; clean shutdown still flushes (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforkinstantmining", _("In shadow fork mode, skip local proof-of-work search and header proof-of-work verification for generated blocks (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforkskiprewind", _("In shadow fork mode, skip startup block-index rewind (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforksuppressibdlogs", _("In shadow fork mode, suppress per-block UpdateTip logs during initial block download (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforkskipversionbitswarnings", _("In shadow fork mode, skip UpdateTip versionbits and unexpected-version warning scans on the inherited block index (default: 1)"));
     }
 
     strUsage += HelpMessageGroup(_("Node relay options:"));

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -48,6 +48,7 @@ private:
 
 public:
     PeerLogicValidation(CConnman* connmanIn);
+    ~PeerLogicValidation() = default;
 
     virtual void SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int nPosInBlock);
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -125,30 +125,36 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             LOCK(cs_main);
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
-        if (!nMineAuxPow) {
-            while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetPoWHash(), pblock->nBits, Params().GetConsensus(nHeight))) {
+        const Consensus::Params& consensus = Params().GetConsensus(nHeight);
+        const bool fShadowForkInstantMining = consensus.fShadowForkMode && GetBoolArg("-shadowforkinstantmining", true);
+        if (fShadowForkInstantMining) {
+            LogPrintf("generateBlocks: shadow fork instant mining enabled; skipping local proof-of-work search\n");
+        } else if (!nMineAuxPow) {
+            while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetPoWHash(), pblock->nBits, consensus)) {
                 ++pblock->nNonce;
                 --nMaxTries;
             }
         } else {
             CAuxPow::initAuxPow(*pblock);
             CPureBlockHeader& miningHeader = pblock->auxpow->parentBlock;
-            while (nMaxTries > 0 && miningHeader.nNonce < nInnerLoopCount && !CheckProofOfWork(miningHeader.GetPoWHash(), pblock->nBits, Params().GetConsensus(nHeight))) {
+            while (nMaxTries > 0 && miningHeader.nNonce < nInnerLoopCount && !CheckProofOfWork(miningHeader.GetPoWHash(), pblock->nBits, consensus)) {
                 ++miningHeader.nNonce;
                 --nMaxTries;
             }
         }
-        if (nMaxTries == 0) {
-            break;
-        }
-        if (!nMineAuxPow) {
-            if (pblock->nNonce == nInnerLoopCount) {
-                continue;
+        if (!fShadowForkInstantMining) {
+            if (nMaxTries == 0) {
+                break;
             }
-        } else {
-            CPureBlockHeader& miningHeader = pblock->auxpow->parentBlock;
-            if (miningHeader.nNonce == nInnerLoopCount) {
-                continue;
+            if (!nMineAuxPow) {
+                if (pblock->nNonce == nInnerLoopCount) {
+                    continue;
+                }
+            } else {
+                CPureBlockHeader& miningHeader = pblock->auxpow->parentBlock;
+                if (miningHeader.nNonce == nInnerLoopCount) {
+                    continue;
+                }
             }
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -2,9 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "chainparams.h"
 #include "util.h"
 #include "test/test_bitcoin.h"
 
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -81,6 +83,29 @@ BOOST_AUTO_TEST_CASE(boolarg)
     BOOST_CHECK(!GetBoolArg("-foo", false));
     BOOST_CHECK(!GetBoolArg("-foo", true));
 
+}
+
+BOOST_AUTO_TEST_CASE(shadowfork_regtest_uses_unique_p2p_magic_and_regtest_disk_magic)
+{
+    static const unsigned char shadowforkMessageStart[CMessageHeader::MESSAGE_START_SIZE] = {
+        0xfd, 0xfd, 0xfd, 0xfd,
+    };
+
+    ResetArgs("-shadowforkchain=regtest");
+    SelectParams(CBaseChainParams::SHADOWFORK);
+
+    const CChainParams& shadowParams = Params();
+    const CChainParams& regtestParams = Params(CBaseChainParams::REGTEST);
+
+    BOOST_CHECK_EQUAL(shadowParams.NetworkIDString(), CBaseChainParams::SHADOWFORK);
+    BOOST_CHECK(std::memcmp(shadowParams.MessageStart(), shadowforkMessageStart,
+                            CMessageHeader::MESSAGE_START_SIZE) == 0);
+    BOOST_CHECK(std::memcmp(shadowParams.DiskMagic(), regtestParams.MessageStart(),
+                            CMessageHeader::MESSAGE_START_SIZE) == 0);
+    BOOST_CHECK(shadowParams.GenesisBlock().GetHash() == regtestParams.GenesisBlock().GetHash());
+
+    ResetArgs("");
+    SelectParams(CBaseChainParams::MAIN);
 }
 
 BOOST_AUTO_TEST_CASE(stringarg)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2034,7 +2034,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             CDiskBlockPos _pos;
             if (!FindUndoPos(state, pindex->nFile, _pos, ::GetSerializeSize(blockundo, SER_DISK, CLIENT_VERSION) + 40))
                 return error("ConnectBlock(): FindUndoPos failed");
-            if (!UndoWriteToDisk(blockundo, _pos, pindex->pprev->GetBlockHash(), chainparams.MessageStart()))
+            if (!UndoWriteToDisk(blockundo, _pos, pindex->pprev->GetBlockHash(), chainparams.DiskMagic()))
                 return AbortNode(state, "Failed to write undo data");
 
             // update nUndoPos in block index
@@ -3390,7 +3390,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
         if (!FindBlockPos(state, blockPos, nBlockSize+8, nHeight, block.GetBlockTime(), dbp != NULL))
             return error("AcceptBlock(): FindBlockPos failed");
         if (dbp == NULL)
-            if (!WriteBlockToDisk(block, blockPos, chainparams.MessageStart()))
+            if (!WriteBlockToDisk(block, blockPos, chainparams.DiskMagic()))
                 AbortNode(state, "Failed to write block");
         if (!ReceivedBlockTransactions(block, state, pindex, blockPos))
             return error("AcceptBlock(): ReceivedBlockTransactions failed");
@@ -4062,7 +4062,7 @@ bool InitBlockIndex(const CChainParams& chainparams)
             CValidationState state;
             if (!FindBlockPos(state, blockPos, nBlockSize+8, 0, block.GetBlockTime()))
                 return error("LoadBlockIndex(): FindBlockPos failed");
-            if (!WriteBlockToDisk(block, blockPos, chainparams.MessageStart()))
+            if (!WriteBlockToDisk(block, blockPos, chainparams.DiskMagic()))
                 return error("LoadBlockIndex(): writing genesis block to disk failed");
             CBlockIndex *pindex = AddToBlockIndex(block);
             if (!ReceivedBlockTransactions(block, state, pindex, blockPos))
@@ -4098,10 +4098,10 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
             try {
                 // locate a header
                 unsigned char buf[CMessageHeader::MESSAGE_START_SIZE];
-                blkdat.FindByte(chainparams.MessageStart()[0]);
+                blkdat.FindByte(chainparams.DiskMagic()[0]);
                 nRewind = blkdat.GetPos()+1;
                 blkdat >> FLATDATA(buf);
-                if (memcmp(buf, chainparams.MessageStart(), CMessageHeader::MESSAGE_START_SIZE))
+                if (memcmp(buf, chainparams.DiskMagic(), CMessageHeader::MESSAGE_START_SIZE))
                     continue;
                 // read size
                 blkdat >> nSize;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1235,8 +1235,14 @@ bool IsInitialBlockDownload()
         return true;
     if (chainActive.Tip()->nChainWork < UintToArith256(chainParams.GetConsensus(chainActive.Height()).nMinimumChainWork))
         return true;
-    if (chainActive.Tip()->GetBlockTime() < (GetTime() - nMaxTipAge))
-        return true;
+    // Shadow fork mode: skip tip age check. The fork is bootstrapped from
+    // source chain data which may have old timestamps (especially regtest
+    // where block timestamps start at genesis epoch 2011). The fork is
+    // by definition up-to-date since it was just created from the source.
+    if (!chainParams.GetConsensus(chainActive.Height()).fShadowForkMode) {
+        if (chainActive.Tip()->GetBlockTime() < (GetTime() - nMaxTipAge))
+            return true;
+    }
     latchToFalse.store(true, std::memory_order_relaxed);
     return false;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -102,6 +102,11 @@ const std::string strMessageMagic = "Dogecoin Signed Message:\n";
 // Internal stuff
 namespace {
 
+    bool IsShadowForkOptimizationEnabled(const CChainParams& params, const char* arg)
+    {
+        return params.GetConsensus(0).fShadowForkMode && GetBoolArg(arg, true);
+    }
+
     struct CBlockIndexWorkComparator
     {
         bool operator()(CBlockIndex *pa, CBlockIndex *pb) const {
@@ -2072,6 +2077,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode, int nManualPruneHeight) {
     int64_t nMempoolUsage = mempool.DynamicMemoryUsage();
     const CChainParams& chainparams = Params();
+    if ((mode == FLUSH_STATE_IF_NEEDED || mode == FLUSH_STATE_PERIODIC) &&
+        IsShadowForkOptimizationEnabled(chainparams, "-shadowforkdeferchainstateflush")) {
+        LogPrint("bench", "FlushStateToDisk: deferred automatic shadow fork flush (mode=%d)\n", mode);
+        return true;
+    }
     LOCK2(cs_main, cs_LastBlockFile);
     static int64_t nLastWrite = 0;
     static int64_t nLastFlush = 0;
@@ -2196,7 +2206,10 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
 
     static bool fWarned = false;
     std::vector<std::string> warningMessages;
-    if (!IsInitialBlockDownload())
+    const bool fInitialBlockDownload = IsInitialBlockDownload();
+    const bool fSkipShadowForkVersionbitsWarnings =
+        IsShadowForkOptimizationEnabled(chainParams, "-shadowforkskipversionbitswarnings");
+    if (!fInitialBlockDownload && !fSkipShadowForkVersionbitsWarnings)
     {
         int nUpgraded = 0;
         const CBlockIndex* pindex = chainActive.Tip();
@@ -2237,14 +2250,18 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
             }
         }
     }
-    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utx)", __func__,
-      chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), chainActive.Tip()->nVersion,
-      log(chainActive.Tip()->nChainWork.getdouble())/log(2.0), (unsigned long)chainActive.Tip()->nChainTx,
-      DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
-      GuessVerificationProgress(chainParams.TxData(), chainActive.Tip()), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
-    if (!warningMessages.empty())
-        LogPrintf(" warning='%s'", boost::algorithm::join(warningMessages, ", "));
-    LogPrintf("\n");
+    const bool fSuppressShadowForkIbdLogs =
+        IsShadowForkOptimizationEnabled(chainParams, "-shadowforksuppressibdlogs");
+    if (!fSuppressShadowForkIbdLogs || !fInitialBlockDownload) {
+        LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utx)", __func__,
+          chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), chainActive.Tip()->nVersion,
+          log(chainActive.Tip()->nChainWork.getdouble())/log(2.0), (unsigned long)chainActive.Tip()->nChainTx,
+          DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
+          GuessVerificationProgress(chainParams.TxData(), chainActive.Tip()), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
+        if (!warningMessages.empty())
+            LogPrintf(" warning='%s'", boost::algorithm::join(warningMessages, ", "));
+        LogPrintf("\n");
+    }
 
 }
 
@@ -2944,7 +2961,9 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, bool f
     // We don't have block height as this is called without context (i.e. without
     // knowing the previous block), but that's okay, as the checks done are permissive
     // (i.e. doesn't check work limit or whether AuxPoW is enabled)
-    if (fCheckPOW && !CheckAuxPowProofOfWork(block, Params().GetConsensus(0)))
+    const Consensus::Params& consensus = Params().GetConsensus(0);
+    const bool fSkipShadowForkPow = consensus.fShadowForkMode && GetBoolArg("-shadowforkinstantmining", true);
+    if (fCheckPOW && !fSkipShadowForkPow && !CheckAuxPowProofOfWork(block, consensus))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
     return true;
@@ -3659,12 +3678,19 @@ CBlockIndex * InsertBlockIndex(uint256 hash)
 
 bool static LoadBlockIndexDB(const CChainParams& chainparams)
 {
+    const int64_t nLoadStart = GetTimeMillis();
+    const bool fShadowForkFastCandidates =
+        IsShadowForkOptimizationEnabled(chainparams, "-shadowforkfastblockindexcandidates");
+
     if (!pblocktree->LoadBlockIndexGuts(InsertBlockIndex))
         return false;
+    LogPrintf("%s: loaded %u block index entries in %dms\n",
+        __func__, (unsigned int)mapBlockIndex.size(), GetTimeMillis() - nLoadStart);
 
     boost::this_thread::interruption_point();
 
     // Calculate nChainWork
+    const int64_t nSortStart = GetTimeMillis();
     std::vector<std::pair<int, CBlockIndex*> > vSortedByHeight;
     vSortedByHeight.reserve(mapBlockIndex.size());
     BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
@@ -3673,6 +3699,10 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
         vSortedByHeight.push_back(std::make_pair(pindex->nHeight, pindex));
     }
     sort(vSortedByHeight.begin(), vSortedByHeight.end());
+    LogPrintf("%s: sorted block index by height in %dms\n",
+        __func__, GetTimeMillis() - nSortStart);
+
+    const int64_t nPostProcessStart = GetTimeMillis();
     BOOST_FOREACH(const PAIRTYPE(int, CBlockIndex*)& item, vSortedByHeight)
     {
         CBlockIndex* pindex = item.second;
@@ -3697,7 +3727,7 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
                 setDirtyBlockIndex.insert(pindex);
             }
         }
-        if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && (pindex->nChainTx || pindex->pprev == NULL))
+        if (!fShadowForkFastCandidates && pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && (pindex->nChainTx || pindex->pprev == NULL))
             setBlockIndexCandidates.insert(pindex);
         if (pindex->nStatus & BLOCK_FAILED_MASK && (!pindexBestInvalid || pindex->nChainWork > pindexBestInvalid->nChainWork))
             pindexBestInvalid = pindex;
@@ -3706,6 +3736,8 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
         if (pindex->IsValid(BLOCK_VALID_TREE) && (pindexBestHeader == NULL || CBlockIndexWorkComparator()(pindexBestHeader, pindex)))
             pindexBestHeader = pindex;
     }
+    LogPrintf("%s: post-processed block index in %dms (shadowfork_fast_candidates=%d)\n",
+        __func__, GetTimeMillis() - nPostProcessStart, fShadowForkFastCandidates);
 
     // Load block file info
     pblocktree->ReadLastBlockFile(nLastBlockFile);
@@ -3762,7 +3794,12 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
         return true;
     chainActive.SetTip(it->second);
 
-    PruneBlockIndexCandidates();
+    if (fShadowForkFastCandidates) {
+        setBlockIndexCandidates.insert(chainActive.Tip());
+        LogPrintf("%s: shadow fork fast candidates enabled; inserted active tip only\n", __func__);
+    } else {
+        PruneBlockIndexCandidates();
+    }
 
     LogPrintf("%s: hashBestChain=%s height=%d date=%s progress=%f\n", __func__,
         chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(),
@@ -3878,6 +3915,11 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
 bool RewindBlockIndex(const CChainParams& params)
 {
     LOCK(cs_main);
+
+    if (IsShadowForkOptimizationEnabled(params, "-shadowforkskiprewind")) {
+        LogPrintf("RewindBlockIndex: skipped in shadow fork mode\n");
+        return true;
+    }
 
     int nHeight = 1;
     while (nHeight <= chainActive.Height()) {


### PR DESCRIPTION
## Summary
- add shadow-fork runtime fast paths for startup and block production
- make the expensive paths runtime-switchable so the orchestrator can disable them per fork
- keep the testnet-node container defaults internally consistent across runtime, healthcheck, and network selection

## Changes
- add `-shadowforkinstantmining` to skip local PoW search and header PoW verification for generated shadow-fork blocks
- add `-shadowforkdeferchainstateflush` to defer automatic chainstate flushes during shadow-fork block production
- add `-shadowforkfastblockindexcandidates` and `-shadowforkskiprewind` to reduce startup work on the inherited block index
- add `-shadowforksuppressibdlogs` and `-shadowforkskipversionbitswarnings` to avoid heavy `UpdateTip()` warning scans on the inherited 49M-entry block index
- add `STRIP_BINARIES` to the testnet-node Dockerfile so local symbol builds can be produced without changing the production path
- align the testnet-node Docker healthcheck with the container's default RPC credentials and network-selected RPC port
- stop loading the testnet config by default when `NETWORK=mainnet` unless `DOGECOIN_CONF` is explicitly set

## Validation
- Built `vladogeos/dogecoin:shadowfork-fastwarnskip-20260416`
- Deployed only through the shadow-fork orchestrator image on DevNet on April 16, 2026
- Warm claim remained sub-second (~0.35s)
- Mining a single block on a claimed fork dropped from a multi-minute hang to `real 0.67`
- Follow-up mine to confirm a wallet transaction completed in `real 0.35`
- Verified mined block hashes persisted at heights `49465921` and `49465923`
- Verified wallet send + confirm flow on the fork (`confirmations_after_mine3=1`)
- Ran `bash -n contrib/docker/testnet-node/scripts/entrypoint.sh`

## Notes
- The main Dogecoin deployment image was not replaced; only the shadow-fork image path was updated during validation.
