### PR TITLE
perf: add active-chain snapshot fast path for shadowforks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+.git
+
+# Local/autotools build outputs must not enter container builds. Stale libtool
+# artifacts, especially bundled UniValue .la files, can make dogecoind link
+# against host-generated paths instead of freshly built Linux artifacts.
+**/.deps
+**/.dirstamp
+**/.libs
+**/Makefile
+**/autom4te.cache
+**/config.log
+**/config.status
+**/libtool
+**/stamp-h1
+**/*.a
+**/*.la
+**/*.lai
+**/*.lo
+**/*.o
+
+# Editor/autoconf backups and local binary drops.
+*~
+**/*~
+build-*.dogecoind
+src/dogecoind
+src/dogecoin-cli
+src/dogecoin-tx

--- a/contrib/docker/testnet-node/Dockerfile
+++ b/contrib/docker/testnet-node/Dockerfile
@@ -66,6 +66,8 @@ RUN find . -type f \( \
 ARG STRIP_BINARIES=1
 
 # Build dogecoind with wallet support (needed for generatetoaddress mining).
+# Utilities stay disabled because shadowfork runtime instances only need the
+# daemon; .dockerignore keeps stale local libtool artifacts out of this build.
 # --with-incompatible-bdb: accept system BDB 5.3 (matches libdb5.3++-dev above).
 # Strip binaries by default to reduce image size.
 RUN ./autogen.sh \
@@ -73,9 +75,10 @@ RUN ./autogen.sh \
         --disable-tests \
         --disable-bench \
         --without-gui \
+        --with-utils=no \
         --with-incompatible-bdb \
     && make -j$(nproc) \
-    && if [ "$STRIP_BINARIES" = "1" ]; then strip src/dogecoind src/dogecoin-cli; fi
+    && if [ "$STRIP_BINARIES" = "1" ]; then strip src/dogecoind; fi
 
 # =============================================================================
 # Stage 2: Runtime image (slim Debian for smaller footprint)
@@ -112,7 +115,6 @@ RUN mkdir -p /data /config /usr/local/bin \
 
 # Copy stripped binaries from builder
 COPY --from=builder /dogecoin/src/dogecoind /usr/local/bin/
-COPY --from=builder /dogecoin/src/dogecoin-cli /usr/local/bin/
 
 # Copy entrypoint script (make world-readable and executable)
 COPY contrib/docker/testnet-node/scripts/entrypoint.sh /entrypoint.sh

--- a/contrib/docker/testnet-node/Dockerfile
+++ b/contrib/docker/testnet-node/Dockerfile
@@ -16,13 +16,18 @@ FROM ubuntu:22.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_APT_MIRROR=
+ARG UBUNTU_SECURITY_MIRROR=
 
 # Install build dependencies
 # Note: libboost-all-dev ensures complete Boost installation with all linking deps
 RUN if [ -n "$UBUNTU_APT_MIRROR" ]; then \
         sed -i "s|http://archive.ubuntu.com/ubuntu|$UBUNTU_APT_MIRROR|g" /etc/apt/sources.list; \
     fi \
-    && apt-get update && apt-get install -y --no-install-recommends \
+    && if [ -n "$UBUNTU_SECURITY_MIRROR" ]; then \
+        sed -i "s|http://security.ubuntu.com/ubuntu|$UBUNTU_SECURITY_MIRROR|g" /etc/apt/sources.list; \
+    fi \
+    && sed -i '/jammy-backports/d' /etc/apt/sources.list \
+    && apt-get -o Acquire::ForceIPv4=true update && apt-get install -y --no-install-recommends \
     build-essential \
     libtool \
     autotools-dev \
@@ -41,6 +46,22 @@ RUN if [ -n "$UBUNTU_APT_MIRROR" ]; then \
 # Copy source code
 WORKDIR /dogecoin
 COPY . .
+
+# Worktrees checked out from Windows can carry CRLF endings. Normalize only
+# build-control text files inside the image so shell/autotools scripts execute.
+RUN find . -type f \( \
+        -name '*.sh' -o \
+        -name '*.ac' -o \
+        -name '*.am' -o \
+        -name '*.m4' -o \
+        -name '*.mk' -o \
+        -name '*.in' -o \
+        -name 'Makefile*' -o \
+        -path './build-aux/*' -o \
+        -path './depends/config.*' -o \
+        -path './src/secp256k1/build-aux/*' -o \
+        -path './src/univalue/build-aux/*' \
+    \) -exec sed -i 's/\r$//' {} +
 
 ARG STRIP_BINARIES=1
 
@@ -95,7 +116,7 @@ COPY --from=builder /dogecoin/src/dogecoin-cli /usr/local/bin/
 
 # Copy entrypoint script (make world-readable and executable)
 COPY contrib/docker/testnet-node/scripts/entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod 755 /entrypoint.sh
 
 # Default environment
 ENV DOGECOIN_DATA=/data

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -138,6 +138,7 @@ BITCOIN_CORE_H = \
   rpc/server.h \
   rpc/register.h \
   scheduler.h \
+  shadowfork_snapshot.h \
   script/sigcache.h \
   script/sign.h \
   script/standard.h \
@@ -218,6 +219,7 @@ libdogecoin_server_a_SOURCES = \
   rpc/net.cpp \
   rpc/rawtransaction.cpp \
   rpc/server.cpp \
+  shadowfork_snapshot.cpp \
   script/sigcache.cpp \
   script/ismine.cpp \
   timedata.cpp \

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -51,18 +51,16 @@ int CMerkleTx::GetDepthInMainChain(const CBlockIndex* &pindexRet) const
 
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
 
-    // In shadowfork mode, historical wallet transactions copied from the frozen
-    // base are trusted input data. Avoid forcing lazy materialization of old
-    // active-chain block index entries just to compute a confirmation depth for
-    // those transactions.
+    // In shadowfork mode, inherited wallet records can point at source-chain
+    // history outside the current fork. Only report depth when active-chain
+    // membership can be proven.
     if (consensus.fShadowForkMode) {
-        CBlockIndex* loaded = FindLoadedBlockIndex(hashBlock);
-        if (loaded && chainActive.Contains(loaded)) {
-            pindexRet = loaded;
-            return ((nIndex == -1) ? (-1) : 1) * (chainActive.Height() - loaded->nHeight + 1);
-        }
-        pindexRet = chainActive.Tip();
-        return ((nIndex == -1) ? (-1) : 1) * (chainActive.Height() + 1);
+        CBlockIndex* pindex = LookupBlockIndex(hashBlock);
+        if (!pindex || !chainActive.Contains(pindex))
+            return 0;
+
+        pindexRet = pindex;
+        return ((nIndex == -1) ? (-1) : 1) * (chainActive.Height() - pindex->nHeight + 1);
     }
 
     // Find the block it claims to be in.

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -49,11 +49,8 @@ int CMerkleTx::GetDepthInMainChain(const CBlockIndex* &pindexRet) const
 
     AssertLockHeld(cs_main);
 
-    // Find the block it claims to be in
-    BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
-    if (mi == mapBlockIndex.end())
-        return 0;
-    CBlockIndex* pindex = (*mi).second;
+    // Find the block it claims to be in.
+    CBlockIndex* pindex = LookupBlockIndex(hashBlock);
     if (!pindex || !chainActive.Contains(pindex))
         return 0;
 

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -49,6 +49,22 @@ int CMerkleTx::GetDepthInMainChain(const CBlockIndex* &pindexRet) const
 
     AssertLockHeld(cs_main);
 
+    const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
+
+    // In shadowfork mode, historical wallet transactions copied from the frozen
+    // base are trusted input data. Avoid forcing lazy materialization of old
+    // active-chain block index entries just to compute a confirmation depth for
+    // those transactions.
+    if (consensus.fShadowForkMode) {
+        CBlockIndex* loaded = FindLoadedBlockIndex(hashBlock);
+        if (loaded && chainActive.Contains(loaded)) {
+            pindexRet = loaded;
+            return ((nIndex == -1) ? (-1) : 1) * (chainActive.Height() - loaded->nHeight + 1);
+        }
+        pindexRet = chainActive.Tip();
+        return ((nIndex == -1) ? (-1) : 1) * (chainActive.Height() + 1);
+    }
+
     // Find the block it claims to be in.
     CBlockIndex* pindex = LookupBlockIndex(hashBlock);
     if (!pindex || !chainActive.Contains(pindex))

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -109,8 +109,15 @@ const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
     }
     if (pindex->nHeight > Height())
         pindex = pindex->GetAncestor(Height());
-    while (pindex && !Contains(pindex))
-        pindex = pindex->pprev;
+    while (pindex && !Contains(pindex)) {
+        if (pindex->pprev) {
+            pindex = pindex->pprev;
+        } else if (pindex->nHeight > 0) {
+            pindex = LoadShadowForkActiveChainIndex(pindex->nHeight - 1);
+        } else {
+            pindex = NULL;
+        }
+    }
     return pindex;
 }
 
@@ -174,7 +181,8 @@ CBlockIndex* CBlockIndex::GetAncestor(int height)
             if (pindexWalk->pprev == NULL) {
                 pindexWalk->pprev = LoadShadowForkActiveChainIndex(heightWalk - 1);
             }
-            assert(pindexWalk->pprev);
+            if (pindexWalk->pprev == NULL)
+                return NULL;
             pindexWalk = pindexWalk->pprev;
             heightWalk--;
         }

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -41,11 +41,29 @@ CBlockHeader CBlockIndex::GetBlockHeader(const Consensus::Params& consensusParam
 void CChain::SetTip(CBlockIndex *pindex) {
     if (pindex == NULL) {
         vChain.clear();
+        nBaseHeight = 0;
         return;
     }
+    nBaseHeight = 0;
     vChain.resize(pindex->nHeight + 1);
     while (pindex && vChain[pindex->nHeight] != pindex) {
         vChain[pindex->nHeight] = pindex;
+        pindex = pindex->pprev;
+    }
+}
+
+void CChain::SetTipWindow(CBlockIndex *pindex, int nWindowStartHeight) {
+    if (pindex == NULL) {
+        vChain.clear();
+        nBaseHeight = 0;
+        return;
+    }
+
+    nBaseHeight = std::max(0, std::min(nWindowStartHeight, pindex->nHeight));
+    vChain.resize(pindex->nHeight - nBaseHeight + 1);
+    while (pindex && pindex->nHeight >= nBaseHeight &&
+           vChain[pindex->nHeight - nBaseHeight] != pindex) {
+        vChain[pindex->nHeight - nBaseHeight] = pindex;
         pindex = pindex->pprev;
     }
 }
@@ -91,9 +109,27 @@ const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
 
 CBlockIndex* CChain::FindEarliestAtLeast(int64_t nTime) const
 {
-    std::vector<CBlockIndex*>::const_iterator lower = std::lower_bound(vChain.begin(), vChain.end(), nTime,
-        [](CBlockIndex* pBlock, const int64_t& time) -> bool { return pBlock->GetBlockTimeMax() < time; });
-    return (lower == vChain.end() ? NULL : *lower);
+    if (vChain.empty()) {
+        return NULL;
+    }
+
+    int low = 0;
+    int high = Height();
+    CBlockIndex* result = NULL;
+    while (low <= high) {
+        const int mid = low + (high - low) / 2;
+        CBlockIndex* pBlock = (*this)[mid];
+        if (pBlock == NULL) {
+            return result;
+        }
+        if (pBlock->GetBlockTimeMax() < nTime) {
+            low = mid + 1;
+        } else {
+            result = pBlock;
+            high = mid - 1;
+        }
+    }
+    return result;
 }
 
 /** Turn the lowest '1' bit in the binary representation of a number into a '0'. */
@@ -128,6 +164,9 @@ CBlockIndex* CBlockIndex::GetAncestor(int height)
             pindexWalk = pindexWalk->pskip;
             heightWalk = heightSkip;
         } else {
+            if (pindexWalk->pprev == NULL) {
+                pindexWalk->pprev = LoadShadowForkActiveChainIndex(heightWalk - 1);
+            }
             assert(pindexWalk->pprev);
             pindexWalk = pindexWalk->pprev;
             heightWalk--;

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -44,10 +44,17 @@ void CChain::SetTip(CBlockIndex *pindex) {
         nBaseHeight = 0;
         return;
     }
-    nBaseHeight = 0;
-    vChain.resize(pindex->nHeight + 1);
-    while (pindex && vChain[pindex->nHeight] != pindex) {
-        vChain[pindex->nHeight] = pindex;
+
+    if (vChain.empty()) {
+        nBaseHeight = 0;
+    } else if (nBaseHeight > pindex->nHeight) {
+        nBaseHeight = pindex->nHeight;
+    }
+
+    vChain.resize(pindex->nHeight - nBaseHeight + 1);
+    while (pindex && pindex->nHeight >= nBaseHeight &&
+           vChain[pindex->nHeight - nBaseHeight] != pindex) {
+        vChain[pindex->nHeight - nBaseHeight] = pindex;
         pindex = pindex->pprev;
     }
 }

--- a/src/chain.h
+++ b/src/chain.h
@@ -500,6 +500,11 @@ public:
         return vChain.empty() ? -1 : nBaseHeight + vChain.size() - 1;
     }
 
+    /** Return the first height kept eagerly in memory. */
+    int WindowStartHeight() const {
+        return vChain.empty() ? -1 : nBaseHeight;
+    }
+
     /** Set/initialize a chain with a given tip. */
     void SetTip(CBlockIndex *pindex);
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -16,6 +16,13 @@
 
 #include <vector>
 
+class CBlockIndex;
+
+/**
+ * Shadowfork-only lazy active-chain lookup hook. Normal nodes return NULL here.
+ */
+CBlockIndex* LoadShadowForkActiveChainIndex(int nHeight);
+
 class CBlockFileInfo
 {
 public:
@@ -290,8 +297,16 @@ public:
         int64_t* pend = &pmedian[nMedianTimeSpan];
 
         const CBlockIndex* pindex = this;
-        for (int i = 0; i < nMedianTimeSpan && pindex; i++, pindex = pindex->pprev)
+        for (int i = 0; i < nMedianTimeSpan && pindex; i++) {
             *(--pbegin) = pindex->GetBlockTime();
+            if (pindex->pprev) {
+                pindex = pindex->pprev;
+            } else if (pindex->nHeight > 0) {
+                pindex = LoadShadowForkActiveChainIndex(pindex->nHeight - 1);
+            } else {
+                pindex = NULL;
+            }
+        }
 
         std::sort(pbegin, pend);
         return pbegin[(pend - pbegin)/2];
@@ -433,11 +448,14 @@ public:
 class CChain {
 private:
     std::vector<CBlockIndex*> vChain;
+    int nBaseHeight;
 
 public:
+    CChain() : nBaseHeight(0) {}
+
     /** Returns the index entry for the genesis block of this chain, or NULL if none. */
     CBlockIndex *Genesis() const {
-        return vChain.size() > 0 ? vChain[0] : NULL;
+        return (*this)[0];
     }
 
     /** Returns the index entry for the tip of this chain, or NULL if none. */
@@ -447,9 +465,13 @@ public:
 
     /** Returns the index entry at a particular height in this chain, or NULL if no such height exists. */
     CBlockIndex *operator[](int nHeight) const {
-        if (nHeight < 0 || nHeight >= (int)vChain.size())
+        if (nHeight < 0 || nHeight > Height())
             return NULL;
-        return vChain[nHeight];
+        if (vChain.empty())
+            return NULL;
+        if (nHeight < nBaseHeight)
+            return LoadShadowForkActiveChainIndex(nHeight);
+        return vChain[nHeight - nBaseHeight];
     }
 
     /** Compare two chains efficiently. */
@@ -460,6 +482,8 @@ public:
 
     /** Efficiently check whether a block is present in this chain. */
     bool Contains(const CBlockIndex *pindex) const {
+        if (pindex == NULL)
+            return false;
         return (*this)[pindex->nHeight] == pindex;
     }
 
@@ -473,11 +497,14 @@ public:
 
     /** Return the maximal height in the chain. Is equal to chain.Tip() ? chain.Tip()->nHeight : -1. */
     int Height() const {
-        return vChain.size() - 1;
+        return vChain.empty() ? -1 : nBaseHeight + vChain.size() - 1;
     }
 
     /** Set/initialize a chain with a given tip. */
     void SetTip(CBlockIndex *pindex);
+
+    /** Set/initialize a chain with a given tip but only keep [nWindowStartHeight, tip] eagerly loaded. */
+    void SetTipWindow(CBlockIndex *pindex, int nWindowStartHeight);
 
     /** Return a CBlockLocator that refers to a block in this chain (by default the tip). */
     CBlockLocator GetLocator(const CBlockIndex *pindex = NULL) const;

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -43,9 +43,7 @@
 #endif
 #endif
 
-#if defined(__APPLE__)
-/* macOS SDK 26+ provides be32dec/be32enc via sys/endian.h (already included from scrypt.h) */
-#elif !defined(__FreeBSD__)
+#if !defined(__FreeBSD__)
 static inline uint32_t be32dec(const void *pp)
 {
 	const uint8_t *p = (uint8_t const *)pp;

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -36,9 +36,7 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
-#if defined(__APPLE__)
-#include <sys/endian.h>
-#elif !defined(__FreeBSD__)
+#if !defined(__FreeBSD__)
 static inline uint32_t le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -480,7 +480,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-shadowforkmaturity=<n>", strprintf(_("Coinbase maturity for shadow fork (default: %d)"), 1));
         strUsage += HelpMessageOpt("-shadowforkfastblockindexcandidates", _("In shadow fork mode, populate block index candidates from the active tip only during startup (default: 1)"));
         strUsage += HelpMessageOpt("-shadowforkdeferchainstateflush", _("In shadow fork mode, defer automatic IF_NEEDED/PERIODIC chainstate flushes; clean shutdown still flushes (default: 1)"));
-        strUsage += HelpMessageOpt("-shadowforkinstantmining", _("In shadow fork mode, skip local proof-of-work search and header proof-of-work verification for generated blocks (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforkinstantmining", _("In shadow fork mode, skip local proof-of-work search and proof-of-work verification for locally submitted or disk-verified blocks (default: 1)"));
         strUsage += HelpMessageOpt("-shadowforkskiprewind", _("In shadow fork mode, skip startup block-index rewind (default: 1)"));
         strUsage += HelpMessageOpt("-shadowforksuppressibdlogs", _("In shadow fork mode, suppress per-block UpdateTip logs during initial block download (default: 1)"));
         strUsage += HelpMessageOpt("-shadowforkskipversionbitswarnings", _("In shadow fork mode, skip UpdateTip versionbits and unexpected-version warning scans on the inherited block index (default: 1)"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -474,6 +474,7 @@ std::string HelpMessage(HelpMessageMode mode)
 
     if (showDebug) {
         strUsage += HelpMessageGroup(_("Shadow fork options (dev/testing):"));
+        strUsage += HelpMessageOpt("-buildshadowforksnapshot", _("Build or refresh the global shadow fork block-index snapshot from the current source datadir and exit"));
         strUsage += HelpMessageOpt("-shadowfork=<height>", _("Enable shadow fork mode, forking from the specified block height"));
         strUsage += HelpMessageOpt("-shadowforkchain=<chain>", _("Source chain to fork from: main or test (default: main)"));
         strUsage += HelpMessageOpt("-shadowforkmaturity=<n>", strprintf(_("Coinbase maturity for shadow fork (default: %d)"), 1));
@@ -483,6 +484,9 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-shadowforkskiprewind", _("In shadow fork mode, skip startup block-index rewind (default: 1)"));
         strUsage += HelpMessageOpt("-shadowforksuppressibdlogs", _("In shadow fork mode, suppress per-block UpdateTip logs during initial block download (default: 1)"));
         strUsage += HelpMessageOpt("-shadowforkskipversionbitswarnings", _("In shadow fork mode, skip UpdateTip versionbits and unexpected-version warning scans on the inherited block index (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforkusesnapshot", _("Use the global shadow fork block-index snapshot during shadow fork startup when available (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforksnapshotroot=<dir>", _("Root directory for shared shadow fork snapshots; defaults to the nearest ancestor shadow-snapshots directory or <datadir>/shadow-snapshots"));
+        strUsage += HelpMessageOpt("-shadowforksnapshotwindow=<n>", _("Eagerly load the newest <n> active-chain block-index entries from the snapshot at startup, lazily loading older active-chain entries on demand (default: 8192)"));
     }
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
@@ -907,6 +911,23 @@ bool AppInitParameterInteraction()
     // ********************************************************* Step 2: parameter interactions
 
     // also see: InitParameterInteraction()
+
+    if (GetBoolArg("-buildshadowforksnapshot", false)) {
+        if (chainparams.GetConsensus(0).fShadowForkMode) {
+            return InitError(_("Shadow fork snapshots must be built from a source main/test datadir, not from a shadow fork datadir."));
+        }
+
+        const std::string network_id = chainparams.NetworkIDString();
+        if (network_id != "main" && network_id != "test") {
+            return InitError(_("Shadow fork snapshots can only be built from main or test source datadirs."));
+        }
+
+        if (GetBoolArg("-reindex", false) || GetBoolArg("-reindex-chainstate", false)) {
+            return InitError(_("Shadow fork snapshot build is incompatible with -reindex and -reindex-chainstate."));
+        }
+
+        LogPrintf("Shadow fork snapshot build requested for source chain %s\n", network_id);
+    }
 
     // Shadow fork parameter validation
     if (IsArgSet("-shadowfork")) {
@@ -1635,6 +1656,16 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         return false;
     }
     LogPrintf(" block index %15dms\n", GetTimeMillis() - nStart);
+
+    if (GetBoolArg("-buildshadowforksnapshot", false))
+    {
+        uiInterface.InitMessage(_("Building shadow fork snapshot..."));
+        if (!BuildShadowForkBlockIndexSnapshot(chainparams))
+            return false;
+        LogPrintf("Shadow fork snapshot built successfully. Shutting down.\n");
+        StartShutdown();
+        return true;
+    }
 
     fs::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
     CAutoFile est_filein(fsbridge::fopen(est_path, "rb"), SER_DISK, CLIENT_VERSION);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -489,6 +489,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-shadowforksnapshotwindow=<n>", _("Eagerly load the newest <n> active-chain block-index entries from the snapshot at startup, lazily loading older active-chain entries on demand (default: 8192)"));
         strUsage += HelpMessageOpt("-shadowforkstartupcut", _("In shadow fork mode, cut the active chain to -shadowfork=<height> during startup instead of requiring external invalidateblock rollback (default: 1)"));
         strUsage += HelpMessageOpt("-shadowforkskipwalletrescan", _("In shadow fork mode, trust the startup-cut tip and skip stale inherited wallet rescans (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforkmemoryonlywallet", _("In shadow fork mode, skip wallet transaction DB loads and keep wallet changes in memory only (default: 0)"));
     }
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
@@ -1615,16 +1616,10 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     }
                 }
 
-                if (chainparams.GetConsensus(0).fShadowForkMode &&
-                    GetBoolArg("-shadowforkstartupcut", true) &&
-                    IsArgSet("-shadowfork")) {
-                    LogPrintf("VerifyDB: skipped before shadow fork startup cut\n");
-                } else {
-                    if (!CVerifyDB().VerifyDB(chainparams, pcoinsdbview, GetArg("-checklevel", DEFAULT_CHECKLEVEL),
-                                  GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
-                        strLoadError = _("Corrupted block database detected");
-                        break;
-                    }
+                if (!CVerifyDB().VerifyDB(chainparams, pcoinsdbview, GetArg("-checklevel", DEFAULT_CHECKLEVEL),
+                              GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
+                    strLoadError = _("Corrupted block database detected");
+                    break;
                 }
 
                 uiInterface.InitMessage(_("Applying shadow fork height..."));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -487,6 +487,8 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-shadowforkusesnapshot", _("Use the global shadow fork block-index snapshot during shadow fork startup when available (default: 1)"));
         strUsage += HelpMessageOpt("-shadowforksnapshotroot=<dir>", _("Root directory for shared shadow fork snapshots; defaults to the nearest ancestor shadow-snapshots directory or <datadir>/shadow-snapshots"));
         strUsage += HelpMessageOpt("-shadowforksnapshotwindow=<n>", _("Eagerly load the newest <n> active-chain block-index entries from the snapshot at startup, lazily loading older active-chain entries on demand (default: 8192)"));
+        strUsage += HelpMessageOpt("-shadowforkstartupcut", _("In shadow fork mode, cut the active chain to -shadowfork=<height> during startup instead of requiring external invalidateblock rollback (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforkskipwalletrescan", _("In shadow fork mode, trust the startup-cut tip and skip stale inherited wallet rescans (default: 1)"));
     }
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
@@ -1613,9 +1615,21 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     }
                 }
 
-                if (!CVerifyDB().VerifyDB(chainparams, pcoinsdbview, GetArg("-checklevel", DEFAULT_CHECKLEVEL),
-                              GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
-                    strLoadError = _("Corrupted block database detected");
+                if (chainparams.GetConsensus(0).fShadowForkMode &&
+                    GetBoolArg("-shadowforkstartupcut", true) &&
+                    IsArgSet("-shadowfork")) {
+                    LogPrintf("VerifyDB: skipped before shadow fork startup cut\n");
+                } else {
+                    if (!CVerifyDB().VerifyDB(chainparams, pcoinsdbview, GetArg("-checklevel", DEFAULT_CHECKLEVEL),
+                                  GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
+                        strLoadError = _("Corrupted block database detected");
+                        break;
+                    }
+                }
+
+                uiInterface.InitMessage(_("Applying shadow fork height..."));
+                if (!ApplyShadowForkStartupCut(chainparams)) {
+                    strLoadError = _("Unable to apply requested shadow fork height");
                     break;
                 }
             } catch (const std::exception& e) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -150,8 +150,7 @@ static bool rest_headers(HTTPRequest* req,
     headers.reserve(count);
     {
         LOCK(cs_main);
-        BlockMap::const_iterator it = mapBlockIndex.find(hash);
-        const CBlockIndex *pindex = (it != mapBlockIndex.end()) ? it->second : NULL;
+        const CBlockIndex *pindex = LookupBlockIndex(hash);
         while (pindex != NULL && chainActive.Contains(pindex)) {
             headers.push_back(pindex);
             if (headers.size() == (unsigned long)count)
@@ -216,10 +215,9 @@ static bool rest_block(HTTPRequest* req,
     CBlockIndex* pblockindex = NULL;
     {
         LOCK(cs_main);
-        if (mapBlockIndex.count(hash) == 0)
+        pblockindex = LookupBlockIndex(hash);
+        if (pblockindex == NULL)
             return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
-
-        pblockindex = mapBlockIndex[hash];
         if (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0)
             return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not available (pruned data)");
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -148,6 +148,9 @@ static bool rest_headers(HTTPRequest* req,
 
     std::vector<const CBlockIndex *> headers;
     headers.reserve(count);
+    CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
+    const CChainParams& chainparams = Params();
+    UniValue jsonHeaders(UniValue::VARR);
     {
         LOCK(cs_main);
         const CBlockIndex *pindex = LookupBlockIndex(hash);
@@ -157,12 +160,12 @@ static bool rest_headers(HTTPRequest* req,
                 break;
             pindex = chainActive.Next(pindex);
         }
-    }
 
-    CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
-    const CChainParams& chainparams = Params();
-    BOOST_FOREACH(const CBlockIndex *pindex, headers) {
-        ssHeader << pindex->GetBlockHeader(chainparams.GetConsensus(pindex->nHeight));
+        BOOST_FOREACH(const CBlockIndex *pindex, headers) {
+            ssHeader << pindex->GetBlockHeader(chainparams.GetConsensus(pindex->nHeight));
+            if (rf == RF_JSON)
+                jsonHeaders.push_back(blockheaderToJSON(pindex));
+        }
     }
 
     switch (rf) {
@@ -180,10 +183,6 @@ static bool rest_headers(HTTPRequest* req,
         return true;
     }
     case RF_JSON: {
-        UniValue jsonHeaders(UniValue::VARR);
-        BOOST_FOREACH(const CBlockIndex *pindex, headers) {
-            jsonHeaders.push_back(blockheaderToJSON(pindex));
-        }
         std::string strJSON = jsonHeaders.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);
@@ -244,7 +243,11 @@ static bool rest_block(HTTPRequest* req,
     }
 
     case RF_JSON: {
-        UniValue objBlock = blockToJSON(block, pblockindex, showTxDetails);
+        UniValue objBlock(UniValue::VOBJ);
+        {
+            LOCK(cs_main);
+            objBlock = blockToJSON(block, pblockindex, showTxDetails);
+        }
         std::string strJSON = objBlock.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);
@@ -385,7 +388,10 @@ static bool rest_tx(HTTPRequest* req, const std::string& strURIPart)
 
     case RF_JSON: {
         UniValue objTx(UniValue::VOBJ);
-        TxToJSON(*tx, hashBlock, objTx);
+        {
+            LOCK(cs_main);
+            TxToJSON(*tx, hashBlock, objTx);
+        }
         std::string strJSON = objTx.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);

--- a/src/rpc/auxpow.cpp
+++ b/src/rpc/auxpow.cpp
@@ -163,7 +163,13 @@ static UniValue AuxMiningSubmitBlock(const uint256 hash, const CAuxPow auxpow)
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
     std::shared_ptr<const CBlock> shared_block = std::make_shared<const CBlock>(block);
-    ProcessNewBlock(Params(), shared_block, true, nullptr);
+    bool fCheckPOW = true;
+    {
+        LOCK(cs_main);
+        const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height() + 1);
+        fCheckPOW = !(consensus.fShadowForkMode && GetBoolArg("-shadowforkinstantmining", true));
+    }
+    ProcessNewBlock(Params(), shared_block, true, nullptr, fCheckPOW);
     UnregisterValidationInterface(&sc);
 
     return BIP22ValidationResult(sc.state);

--- a/src/rpc/auxpow.cpp
+++ b/src/rpc/auxpow.cpp
@@ -37,6 +37,21 @@ static std::vector<std::unique_ptr<CBlockTemplate>> vNewBlockTemplate;
 
 void AuxMiningCheck()
 {
+    bool fShadowForkMode = false;
+
+    /* This should never fail, since the chain is already
+       past the point of merge-mining start.  Check nevertheless.  */
+    {
+        LOCK(cs_main);
+        const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height() + 1);
+        fShadowForkMode = consensus.fShadowForkMode;
+        if (!fShadowForkMode && consensus.fAllowLegacyBlocks)
+            throw std::runtime_error("getauxblock method is not yet available");
+    }
+
+    if (fShadowForkMode)
+        return;
+
     if(!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
@@ -46,14 +61,6 @@ void AuxMiningCheck()
     if (IsInitialBlockDownload() && !Params().MineBlocksOnDemand())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
                            "Dogecoin is downloading blocks...");
-
-    /* This should never fail, since the chain is already
-       past the point of merge-mining start.  Check nevertheless.  */
-    {
-        LOCK(cs_main);
-        if (Params().GetConsensus(chainActive.Height() + 1).fAllowLegacyBlocks)
-            throw std::runtime_error("getauxblock method is not yet available");
-    }
 }
 
 static UniValue AuxMiningCreateBlock(const CScript& scriptPubKey)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -189,8 +189,9 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     if (block.auxpow)
         result.pushKV("auxpow", AuxpowToJSON(*block.auxpow));
 
+    const bool on_active_chain = chainActive.Contains(blockindex);
     const CBlockIndex* pprev = blockindex->pprev;
-    if (pprev == NULL && blockindex->nHeight > 0) {
+    if (pprev == NULL && on_active_chain && blockindex->nHeight > 0) {
         pprev = chainActive[blockindex->nHeight - 1];
     }
     if (pprev)
@@ -773,7 +774,7 @@ static CBlockUndo GetUndoChecked(const CBlockIndex* pblockindex)
     }
 
     const CBlockIndex* pprev = pblockindex->pprev;
-    if (pprev == NULL && pblockindex->nHeight > 0) {
+    if (pprev == NULL && chainActive.Contains(pblockindex) && pblockindex->nHeight > 0) {
         pprev = chainActive[pblockindex->nHeight - 1];
     }
     if (pprev == NULL || !UndoReadFromDisk(blockUndo, pblockindex->GetUndoPos(), pprev->GetBlockHash())) {
@@ -855,17 +856,15 @@ UniValue getblock(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
 
         block = GetBlockChecked(pblockindex);
+
+        if (verbosity > 0)
+            return blockToJSON(block, pblockindex, verbosity >= 2);
     }
 
-    if (verbosity <= 0)
-    {
-        CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
-        ssBlock << block;
-        std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
-        return strHex;
-    }
-
-    return blockToJSON(block, pblockindex, verbosity >= 2);
+    CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
+    ssBlock << block;
+    std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
+    return strHex;
 }
 
 struct CCoinsStats

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -137,8 +137,9 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("chainwork", blockindex->nChainWork.GetHex());
 
+    const bool on_active_chain = chainActive.Contains(blockindex);
     const CBlockIndex* pprev = blockindex->pprev;
-    if (pprev == NULL && blockindex->nHeight > 0) {
+    if (pprev == NULL && on_active_chain && blockindex->nHeight > 0) {
         pprev = chainActive[blockindex->nHeight - 1];
     }
     if (pprev)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -137,8 +137,12 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("chainwork", blockindex->nChainWork.GetHex());
 
-    if (blockindex->pprev)
-        result.pushKV("previousblockhash", blockindex->pprev->GetBlockHash().GetHex());
+    const CBlockIndex* pprev = blockindex->pprev;
+    if (pprev == NULL && blockindex->nHeight > 0) {
+        pprev = chainActive[blockindex->nHeight - 1];
+    }
+    if (pprev)
+        result.pushKV("previousblockhash", pprev->GetBlockHash().GetHex());
     CBlockIndex *pnext = chainActive.Next(blockindex);
     if (pnext)
         result.pushKV("nextblockhash", pnext->GetBlockHash().GetHex());
@@ -184,8 +188,12 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     if (block.auxpow)
         result.pushKV("auxpow", AuxpowToJSON(*block.auxpow));
 
-    if (blockindex->pprev)
-        result.pushKV("previousblockhash", blockindex->pprev->GetBlockHash().GetHex());
+    const CBlockIndex* pprev = blockindex->pprev;
+    if (pprev == NULL && blockindex->nHeight > 0) {
+        pprev = chainActive[blockindex->nHeight - 1];
+    }
+    if (pprev)
+        result.pushKV("previousblockhash", pprev->GetBlockHash().GetHex());
     CBlockIndex *pnext = chainActive.Next(blockindex);
     if (pnext)
         result.pushKV("nextblockhash", pnext->GetBlockHash().GetHex());
@@ -718,10 +726,9 @@ UniValue getblockheader(const JSONRPCRequest& request)
     if (request.params.size() > 1)
         fVerbose = request.params[1].get_bool();
 
-    if (mapBlockIndex.count(hash) == 0)
+    CBlockIndex* pblockindex = LookupBlockIndex(hash);
+    if (pblockindex == NULL)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-
-    CBlockIndex* pblockindex = mapBlockIndex[hash];
 
     if (!fVerbose)
     {
@@ -764,7 +771,11 @@ static CBlockUndo GetUndoChecked(const CBlockIndex* pblockindex)
         throw JSONRPCError(RPC_MISC_ERROR, "Undo data not available (pruned data)");
     }
 
-    if (!UndoReadFromDisk(blockUndo, pblockindex->GetUndoPos(), pblockindex->pprev->GetBlockHash())) {
+    const CBlockIndex* pprev = pblockindex->pprev;
+    if (pprev == NULL && pblockindex->nHeight > 0) {
+        pprev = chainActive[pblockindex->nHeight - 1];
+    }
+    if (pprev == NULL || !UndoReadFromDisk(blockUndo, pblockindex->GetUndoPos(), pprev->GetBlockHash())) {
         throw JSONRPCError(RPC_MISC_ERROR, "Can't read undo data from disk");
     }
 
@@ -838,10 +849,9 @@ UniValue getblock(const JSONRPCRequest& request)
     {
         LOCK(cs_main);
 
-        if (mapBlockIndex.count(hash) == 0)
+        pblockindex = LookupBlockIndex(hash);
+        if (pblockindex == NULL)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-
-        pblockindex = mapBlockIndex[hash];
 
         block = GetBlockChecked(pblockindex);
     }
@@ -879,7 +889,11 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
     stats.hashBlock = pcursor->GetBestBlock();
     {
         LOCK(cs_main);
-        stats.nHeight = mapBlockIndex.find(stats.hashBlock)->second->nHeight;
+        CBlockIndex* pindex = LookupBlockIndex(stats.hashBlock);
+        if (pindex == NULL) {
+            return false;
+        }
+        stats.nHeight = pindex->nHeight;
     }
     ss << stats.hashBlock;
     arith_uint256 nTotalAmount = 0;
@@ -1440,10 +1454,9 @@ UniValue preciousblock(const JSONRPCRequest& request)
 
     {
         LOCK(cs_main);
-        if (mapBlockIndex.count(hash) == 0)
+        pblockindex = LookupBlockIndex(hash);
+        if (pblockindex == NULL)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-
-        pblockindex = mapBlockIndex[hash];
     }
 
     CValidationState state;
@@ -1476,10 +1489,9 @@ UniValue invalidateblock(const JSONRPCRequest& request)
 
     {
         LOCK(cs_main);
-        if (mapBlockIndex.count(hash) == 0)
+        CBlockIndex* pblockindex = LookupBlockIndex(hash);
+        if (pblockindex == NULL)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-
-        CBlockIndex* pblockindex = mapBlockIndex[hash];
         InvalidateBlock(state, Params(), pblockindex);
     }
 
@@ -1514,10 +1526,9 @@ UniValue reconsiderblock(const JSONRPCRequest& request)
 
     {
         LOCK(cs_main);
-        if (mapBlockIndex.count(hash) == 0)
+        CBlockIndex* pblockindex = LookupBlockIndex(hash);
+        if (pblockindex == NULL)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-
-        CBlockIndex* pblockindex = mapBlockIndex[hash];
         ResetBlockFailureFlags(pblockindex);
     }
 
@@ -1651,9 +1662,9 @@ static UniValue getblockstats(const JSONRPCRequest& request)
     CBlockIndex* pindex;
     const uint256 hash = ParseHashV(request.params[0], "hash");
 
-    if (mapBlockIndex.count(hash) == 0)
+    pindex = LookupBlockIndex(hash);
+    if (pindex == NULL)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-    pindex = mapBlockIndex[hash];
 
     if (!chainActive.Contains(pindex)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Block is not in chain %s", Params().NetworkIDString()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -165,7 +165,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             }
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        if (!ProcessNewBlock(Params(), shared_pblock, true, NULL)) {
+        if (!ProcessNewBlock(Params(), shared_pblock, true, NULL, !fShadowForkInstantMining)) {
             if (nMineAuxPow) {
                 continue;
             }
@@ -815,18 +815,21 @@ UniValue submitblock(const JSONRPCRequest& request)
         }
     }
 
+    bool fCheckPOW = true;
     {
         LOCK(cs_main);
         CBlockIndex* pprev = LookupBlockIndex(block.hashPrevBlock);
         if (pprev != NULL) {
-            int nHeight = chainActive.Height() + 1;
-            UpdateUncommittedBlockStructures(block, pprev, Params().GetConsensus(nHeight));
+            int nHeight = pprev->nHeight + 1;
+            const Consensus::Params& consensus = Params().GetConsensus(nHeight);
+            fCheckPOW = !(consensus.fShadowForkMode && GetBoolArg("-shadowforkinstantmining", true));
+            UpdateUncommittedBlockStructures(block, pprev, consensus);
         }
     }
 
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
-    bool fAccepted = ProcessNewBlock(Params(), blockptr, true, NULL);
+    bool fAccepted = ProcessNewBlock(Params(), blockptr, true, NULL, fCheckPOW);
     UnregisterValidationInterface(&sc);
     if (fBlockPresent)
     {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -56,12 +56,17 @@ UniValue GetNetworkHashPS(int lookup, int height) {
     if (lookup > pb->nHeight)
         lookup = pb->nHeight;
 
-    CBlockIndex *pb0 = pb;
+    CBlockIndex *pb0 = chainActive[pb->nHeight - lookup];
+    if (pb0 == NULL)
+        return 0;
+
     int64_t minTime = pb0->GetBlockTime();
     int64_t maxTime = minTime;
-    for (int i = 0; i < lookup; i++) {
-        pb0 = pb0->pprev;
-        int64_t time = pb0->GetBlockTime();
+    for (int cursor_height = pb0->nHeight + 1; cursor_height <= pb->nHeight; ++cursor_height) {
+        CBlockIndex* cursor = chainActive[cursor_height];
+        if (cursor == NULL)
+            return 0;
+        int64_t time = cursor->GetBlockTime();
         minTime = std::min(time, minTime);
         maxTime = std::max(time, maxTime);
     }
@@ -127,6 +132,9 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
         }
         const Consensus::Params& consensus = Params().GetConsensus(nHeight);
         const bool fShadowForkInstantMining = consensus.fShadowForkMode && GetBoolArg("-shadowforkinstantmining", true);
+        if (nMineAuxPow) {
+            CAuxPow::initAuxPow(*pblock);
+        }
         if (fShadowForkInstantMining) {
             LogPrintf("generateBlocks: shadow fork instant mining enabled; skipping local proof-of-work search\n");
         } else if (!nMineAuxPow) {
@@ -135,7 +143,6 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
                 --nMaxTries;
             }
         } else {
-            CAuxPow::initAuxPow(*pblock);
             CPureBlockHeader& miningHeader = pblock->auxpow->parentBlock;
             while (nMaxTries > 0 && miningHeader.nNonce < nInnerLoopCount && !CheckProofOfWork(miningHeader.GetPoWHash(), pblock->nBits, consensus)) {
                 ++miningHeader.nNonce;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -470,9 +470,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                 throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
             uint256 hash = block.GetHash();
-            BlockMap::iterator mi = mapBlockIndex.find(hash);
-            if (mi != mapBlockIndex.end()) {
-                CBlockIndex *pindex = mi->second;
+            CBlockIndex *pindex = LookupBlockIndex(hash);
+            if (pindex != NULL) {
                 if (pindex->IsValid(BLOCK_VALID_SCRIPTS))
                     return "duplicate";
                 if (pindex->nStatus & BLOCK_FAILED_MASK)
@@ -798,9 +797,8 @@ UniValue submitblock(const JSONRPCRequest& request)
     bool fBlockPresent = false;
     {
         LOCK(cs_main);
-        BlockMap::iterator mi = mapBlockIndex.find(hash);
-        if (mi != mapBlockIndex.end()) {
-            CBlockIndex *pindex = mi->second;
+        CBlockIndex *pindex = LookupBlockIndex(hash);
+        if (pindex != NULL) {
             if (pindex->IsValid(BLOCK_VALID_SCRIPTS))
                 return "duplicate";
             if (pindex->nStatus & BLOCK_FAILED_MASK)
@@ -812,10 +810,10 @@ UniValue submitblock(const JSONRPCRequest& request)
 
     {
         LOCK(cs_main);
-        BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
-        if (mi != mapBlockIndex.end()) {
+        CBlockIndex* pprev = LookupBlockIndex(block.hashPrevBlock);
+        if (pprev != NULL) {
             int nHeight = chainActive.Height() + 1;
-            UpdateUncommittedBlockStructures(block, mi->second, Params().GetConsensus(nHeight));
+            UpdateUncommittedBlockStructures(block, pprev, Params().GetConsensus(nHeight));
         }
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -110,6 +110,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
 
     if (!hashBlock.IsNull()) {
         entry.pushKV("blockhash", hashBlock.GetHex());
+        LOCK(cs_main);
         CBlockIndex* pindex = LookupBlockIndex(hashBlock);
         if (pindex) {
             if (chainActive.Contains(pindex)) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -110,16 +110,15 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
 
     if (!hashBlock.IsNull()) {
         entry.pushKV("blockhash", hashBlock.GetHex());
-        BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
-        if (mi != mapBlockIndex.end() && (*mi).second) {
-            CBlockIndex* pindex = (*mi).second;
+        CBlockIndex* pindex = LookupBlockIndex(hashBlock);
+        if (pindex) {
             if (chainActive.Contains(pindex)) {
                 entry.pushKV("confirmations", 1 + chainActive.Height() - pindex->nHeight);
                 entry.pushKV("time", pindex->GetBlockTime());
                 entry.pushKV("blocktime", pindex->GetBlockTime());
-            }
-            else
+            } else {
                 entry.pushKV("confirmations", 0);
+            }
         }
     }
 }
@@ -280,9 +279,9 @@ UniValue gettxoutproof(const JSONRPCRequest& request)
     if (request.params.size() > 1)
     {
         hashBlock = uint256S(request.params[1].get_str());
-        if (!mapBlockIndex.count(hashBlock))
+        pblockindex = LookupBlockIndex(hashBlock);
+        if (pblockindex == NULL)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-        pblockindex = mapBlockIndex[hashBlock];
     } else {
         CCoins coins;
         if (pcoinsTip->GetCoins(oneTxid, coins) && coins.nHeight > 0 && coins.nHeight <= chainActive.Height())
@@ -294,9 +293,9 @@ UniValue gettxoutproof(const JSONRPCRequest& request)
         CTransactionRef tx;
         if (!GetTransaction(oneTxid, tx, Params().GetConsensus(0), hashBlock, false) || hashBlock.IsNull())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
-        if (!mapBlockIndex.count(hashBlock))
+        pblockindex = LookupBlockIndex(hashBlock);
+        if (pblockindex == NULL)
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");
-        pblockindex = mapBlockIndex[hashBlock];
     }
 
     CBlock block;
@@ -343,7 +342,8 @@ UniValue verifytxoutproof(const JSONRPCRequest& request)
 
     LOCK(cs_main);
 
-    if (!mapBlockIndex.count(merkleBlock.header.GetHash()) || !chainActive.Contains(mapBlockIndex[merkleBlock.header.GetHash()]))
+    CBlockIndex* pindex = LookupBlockIndex(merkleBlock.header.GetHash());
+    if (pindex == NULL || !chainActive.Contains(pindex))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found in chain");
 
     BOOST_FOREACH(const uint256& hash, vMatch)

--- a/src/shadowfork_snapshot.cpp
+++ b/src/shadowfork_snapshot.cpp
@@ -1,0 +1,294 @@
+// Copyright (c) 2026 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "shadowfork_snapshot.h"
+
+#include "clientversion.h"
+#include "chainparams.h"
+#include "streams.h"
+#include "util.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+static const unsigned char SHADOWFORK_SNAPSHOT_MAGIC[] = {
+    's', 'f', 'b', 'l', 'k', 'i', 'd', 'x'
+};
+
+static const uint32_t SHADOWFORK_SNAPSHOT_VERSION = 2;
+static const long SHADOWFORK_ACTIVE_CHAIN_RECORD_SIZE = 72;
+
+static fs::path GetShadowForkSnapshotRoot()
+{
+    const std::string configured_root = GetArg("-shadowforksnapshotroot", "");
+    if (!configured_root.empty()) {
+        return fs::path(configured_root);
+    }
+
+    const fs::path data_root = GetDataDir(false);
+    for (fs::path cursor = data_root; !cursor.empty(); cursor = cursor.parent_path()) {
+        const fs::path candidate = cursor / "shadow-snapshots";
+        if (fs::exists(candidate) && fs::is_directory(candidate)) {
+            return candidate;
+        }
+
+        const fs::path parent = cursor.parent_path();
+        if (parent == cursor) {
+            break;
+        }
+    }
+
+    return data_root / "shadow-snapshots";
+}
+
+static fs::path GetShadowForkSnapshotDirectory(const std::string& source_chain)
+{
+    return GetShadowForkSnapshotRoot() / source_chain;
+}
+
+} // namespace
+
+fs::path GetShadowForkSnapshotPath(const std::string& source_chain)
+{
+    return GetShadowForkSnapshotDirectory(source_chain) / "blockindex.dat";
+}
+
+std::string GetShadowForkSnapshotSourceChain(const CChainParams& chainparams)
+{
+    if (chainparams.GetConsensus(0).fShadowForkMode) {
+        return GetArg("-shadowforkchain", "main");
+    }
+    return chainparams.NetworkIDString();
+}
+
+ShadowForkSnapshotWriter::ShadowForkSnapshotWriter()
+{
+}
+
+ShadowForkSnapshotWriter::~ShadowForkSnapshotWriter()
+{
+}
+
+bool ShadowForkSnapshotWriter::SetError(const std::string& message, std::string* error)
+{
+    if (error) {
+        *error = message;
+    }
+    return false;
+}
+
+bool ShadowForkSnapshotWriter::Open(const std::string& source_chain, std::string* error)
+{
+    final_path_ = GetShadowForkSnapshotPath(source_chain);
+    temp_path_ = final_path_;
+    temp_path_ += ".new";
+
+    try {
+        fs::create_directories(final_path_.parent_path());
+    } catch (const fs::filesystem_error& e) {
+        return SetError(strprintf("failed to create snapshot directory %s: %s",
+                                  final_path_.parent_path().string(), e.what()), error);
+    }
+
+    FILE* raw_file = fsbridge::fopen(temp_path_, "wb");
+    if (!raw_file) {
+        return SetError(strprintf("failed to open snapshot temp file %s", temp_path_.string()), error);
+    }
+
+    file_.reset(new CAutoFile(raw_file, SER_DISK, CLIENT_VERSION));
+
+    try {
+        (*file_) << FLATDATA(SHADOWFORK_SNAPSHOT_MAGIC);
+        (*file_) << SHADOWFORK_SNAPSHOT_VERSION;
+    } catch (const std::exception& e) {
+        file_.reset();
+        return SetError(strprintf("failed to write snapshot header: %s", e.what()), error);
+    }
+
+    return true;
+}
+
+bool ShadowForkSnapshotWriter::WriteMetadata(const ShadowForkSnapshotMetadata& metadata, std::string* error)
+{
+    if (!file_) {
+        return SetError("snapshot writer is not open", error);
+    }
+
+    try {
+        (*file_) << metadata;
+    } catch (const std::exception& e) {
+        return SetError(strprintf("failed to write snapshot metadata: %s", e.what()), error);
+    }
+
+    return true;
+}
+
+bool ShadowForkSnapshotWriter::WriteActiveChainRecord(const ShadowForkActiveChainRecord& record, std::string* error)
+{
+    if (!file_) {
+        return SetError("snapshot writer is not open", error);
+    }
+
+    try {
+        (*file_) << record;
+    } catch (const std::exception& e) {
+        return SetError(strprintf("failed to write snapshot active-chain record: %s", e.what()), error);
+    }
+
+    return true;
+}
+
+bool ShadowForkSnapshotWriter::Commit(std::string* error)
+{
+    if (!file_) {
+        return SetError("snapshot writer is not open", error);
+    }
+
+    try {
+        FileCommit(file_->Get());
+        file_->fclose();
+        file_.reset();
+        if (!RenameOver(temp_path_, final_path_)) {
+            return SetError(strprintf("failed to replace snapshot file %s", final_path_.string()), error);
+        }
+    } catch (const std::exception& e) {
+        return SetError(strprintf("failed to commit snapshot file: %s", e.what()), error);
+    }
+
+    return true;
+}
+
+ShadowForkSnapshotReader::ShadowForkSnapshotReader()
+    : record_count_(0),
+      remaining_records_(0),
+      records_offset_(0),
+      metadata_loaded_(false)
+{
+}
+
+ShadowForkSnapshotReader::~ShadowForkSnapshotReader()
+{
+}
+
+bool ShadowForkSnapshotReader::SetError(const std::string& message, std::string* error)
+{
+    if (error) {
+        *error = message;
+    }
+    return false;
+}
+
+bool ShadowForkSnapshotReader::Open(const std::string& source_chain, std::string* error)
+{
+    path_ = GetShadowForkSnapshotPath(source_chain);
+
+    FILE* raw_file = fsbridge::fopen(path_, "rb");
+    if (!raw_file) {
+        return SetError(strprintf("snapshot file %s does not exist", path_.string()), error);
+    }
+
+    file_.reset(new CAutoFile(raw_file, SER_DISK, CLIENT_VERSION));
+
+    try {
+        unsigned char magic[sizeof(SHADOWFORK_SNAPSHOT_MAGIC)];
+        uint32_t version = 0;
+        (*file_) >> FLATDATA(magic);
+        (*file_) >> version;
+        if (std::memcmp(magic, SHADOWFORK_SNAPSHOT_MAGIC, sizeof(SHADOWFORK_SNAPSHOT_MAGIC)) != 0) {
+            file_.reset();
+            return SetError(strprintf("snapshot file %s has an invalid magic header", path_.string()), error);
+        }
+        if (version != SHADOWFORK_SNAPSHOT_VERSION) {
+            file_.reset();
+            return SetError(strprintf("snapshot file %s has unsupported version %u", path_.string(), version), error);
+        }
+    } catch (const std::exception& e) {
+        file_.reset();
+        return SetError(strprintf("failed to read snapshot header from %s: %s", path_.string(), e.what()), error);
+    }
+
+    return true;
+}
+
+bool ShadowForkSnapshotReader::ReadMetadata(ShadowForkSnapshotMetadata& metadata, std::string* error)
+{
+    if (!file_) {
+        return SetError("snapshot reader is not open", error);
+    }
+
+    try {
+        (*file_) >> metadata;
+        record_count_ = metadata.block_count;
+        remaining_records_ = metadata.block_count;
+        records_offset_ = std::ftell(file_->Get());
+        if (records_offset_ < 0) {
+            return SetError(strprintf("failed to determine snapshot record offset for %s", path_.string()), error);
+        }
+        metadata_loaded_ = true;
+    } catch (const std::exception& e) {
+        return SetError(strprintf("failed to read snapshot metadata: %s", e.what()), error);
+    }
+
+    return true;
+}
+
+bool ShadowForkSnapshotReader::ReadNextActiveChainRecord(ShadowForkActiveChainRecord& record, std::string* error)
+{
+    if (!file_) {
+        return SetError("snapshot reader is not open", error);
+    }
+    if (!metadata_loaded_) {
+        return SetError("snapshot metadata has not been loaded", error);
+    }
+    if (remaining_records_ == 0) {
+        return SetError("snapshot has no remaining block records", error);
+    }
+
+    try {
+        (*file_) >> record;
+        --remaining_records_;
+    } catch (const std::exception& e) {
+        return SetError(strprintf("failed to read snapshot active-chain record: %s", e.what()), error);
+    }
+
+    return true;
+}
+
+bool ShadowForkSnapshotReader::ReadActiveChainRecordAtHeight(int height, ShadowForkActiveChainRecord& record, std::string* error)
+{
+    if (!file_) {
+        return SetError("snapshot reader is not open", error);
+    }
+    if (!metadata_loaded_) {
+        return SetError("snapshot metadata has not been loaded", error);
+    }
+    if (height < 0 || static_cast<uint64_t>(height) >= record_count_) {
+        return SetError(strprintf("snapshot height %d is out of range", height), error);
+    }
+
+    const long offset = records_offset_ + static_cast<long>(height) * SHADOWFORK_ACTIVE_CHAIN_RECORD_SIZE;
+    if (std::fseek(file_->Get(), offset, SEEK_SET) != 0) {
+        return SetError(strprintf("failed to seek snapshot record at height %d", height), error);
+    }
+
+    try {
+        (*file_) >> record;
+    } catch (const std::exception& e) {
+        return SetError(strprintf("failed to read snapshot record at height %d: %s", height, e.what()), error);
+    }
+
+    return true;
+}
+
+uint64_t ShadowForkSnapshotReader::RemainingRecords() const
+{
+    return remaining_records_;
+}
+
+uint64_t ShadowForkSnapshotReader::RecordCount() const
+{
+    return record_count_;
+}

--- a/src/shadowfork_snapshot.h
+++ b/src/shadowfork_snapshot.h
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SHADOWFORK_SNAPSHOT_H
+#define BITCOIN_SHADOWFORK_SNAPSHOT_H
+
+#include "chain.h"
+#include "fs.h"
+#include "serialize.h"
+
+#include <memory>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+class CAutoFile;
+class CChainParams;
+
+struct ShadowForkSnapshotMetadata
+{
+    std::string source_chain;
+    uint256 genesis_hash;
+    uint256 active_tip_hash;
+    int active_tip_height;
+    bool tx_index;
+    bool have_pruned;
+    int last_block_file;
+    uint64_t block_count;
+    std::vector<CBlockFileInfo> block_file_info;
+
+    ShadowForkSnapshotMetadata()
+        : active_tip_height(-1),
+          tx_index(false),
+          have_pruned(false),
+          last_block_file(0),
+          block_count(0)
+    {
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(source_chain);
+        READWRITE(genesis_hash);
+        READWRITE(active_tip_hash);
+        READWRITE(active_tip_height);
+        READWRITE(tx_index);
+        READWRITE(have_pruned);
+        READWRITE(last_block_file);
+        READWRITE(VARINT(block_count));
+        READWRITE(block_file_info);
+    }
+};
+
+struct ShadowForkActiveChainRecord
+{
+    uint256 block_hash;
+    uint256 chain_work;
+    uint32_t chain_tx_count;
+    uint32_t time_max;
+
+    ShadowForkActiveChainRecord()
+        : chain_tx_count(0),
+          time_max(0)
+    {
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(block_hash);
+        READWRITE(chain_work);
+        READWRITE(chain_tx_count);
+        READWRITE(time_max);
+    }
+};
+
+fs::path GetShadowForkSnapshotPath(const std::string& source_chain);
+std::string GetShadowForkSnapshotSourceChain(const CChainParams& chainparams);
+
+class ShadowForkSnapshotWriter
+{
+public:
+    ShadowForkSnapshotWriter();
+    ~ShadowForkSnapshotWriter();
+
+    bool Open(const std::string& source_chain, std::string* error);
+    bool WriteMetadata(const ShadowForkSnapshotMetadata& metadata, std::string* error);
+    bool WriteActiveChainRecord(const ShadowForkActiveChainRecord& record, std::string* error);
+    bool Commit(std::string* error);
+
+private:
+    bool SetError(const std::string& message, std::string* error);
+
+    fs::path final_path_;
+    fs::path temp_path_;
+    std::unique_ptr<CAutoFile> file_;
+};
+
+class ShadowForkSnapshotReader
+{
+public:
+    ShadowForkSnapshotReader();
+    ~ShadowForkSnapshotReader();
+
+    bool Open(const std::string& source_chain, std::string* error);
+    bool ReadMetadata(ShadowForkSnapshotMetadata& metadata, std::string* error);
+    bool ReadNextActiveChainRecord(ShadowForkActiveChainRecord& record, std::string* error);
+    bool ReadActiveChainRecordAtHeight(int height, ShadowForkActiveChainRecord& record, std::string* error);
+    uint64_t RemainingRecords() const;
+    uint64_t RecordCount() const;
+
+private:
+    bool SetError(const std::string& message, std::string* error);
+
+    fs::path path_;
+    std::unique_ptr<CAutoFile> file_;
+    uint64_t record_count_;
+    uint64_t remaining_records_;
+    long records_offset_;
+    bool metadata_loaded_;
+};
+
+#endif // BITCOIN_SHADOWFORK_SNAPSHOT_H

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -154,6 +154,10 @@ bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) {
     return Read(std::make_pair(DB_TXINDEX, txid), pos);
 }
 
+bool CBlockTreeDB::ReadBlockIndex(const uint256 &hash, CDiskBlockIndex &diskindex) {
+    return Read(std::make_pair(DB_BLOCK_INDEX, hash), diskindex);
+}
+
 bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >&vect) {
     CDBBatch batch(*this);
     for (std::vector<std::pair<uint256,CDiskTxPos> >::const_iterator it=vect.begin(); it!=vect.end(); it++)

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -118,6 +118,7 @@ public:
     bool WriteReindexing(bool fReindex);
     bool ReadReindexing(bool &fReindex);
     bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
+    bool ReadBlockIndex(const uint256 &hash, CDiskBlockIndex &diskindex);
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -534,7 +534,13 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp, bool 
                     maxInputHeight = std::max(maxInputHeight, height);
                 }
             }
-            if (IsBelowShadowForkStartupCutWindow(maxInputHeight)) {
+            // If no relative lock-time constraints survived CalculateSequenceLocks()
+            // then these LockPoints do not depend on any historical block. Avoid
+            // asking lazy shadowfork indexes to materialize the genesis ancestor
+            // for version-2 transactions whose sequences disable BIP68.
+            if (lockPair.first == -1 && lockPair.second == -1) {
+                lp->maxInputBlock = NULL;
+            } else if (IsBelowShadowForkStartupCutWindow(maxInputHeight)) {
                 // Shadowfork prepared volumes can contain very old inherited
                 // UTXOs. Caching a lockpoint for those inputs forces lazy
                 // materialization of a deep source-chain ancestor while
@@ -4186,6 +4192,14 @@ CBlockIndex* LookupBlockIndex(const uint256& hash)
         return NULL;
     }
     return pindex;
+}
+
+CBlockIndex* FindLoadedBlockIndex(const uint256& hash)
+{
+    AssertLockHeld(cs_main);
+
+    BlockMap::iterator it = mapBlockIndex.find(hash);
+    return it == mapBlockIndex.end() ? NULL : it->second;
 }
 
 static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -27,6 +27,7 @@
 #include "random.h"
 #include "script/script.h"
 #include "script/sigcache.h"
+#include "shadowfork_snapshot.h"
 #include "script/standard.h"
 #include "timedata.h"
 #include "tinyformat.h"
@@ -87,11 +88,6 @@ CAmount maxTxFee = DEFAULT_TRANSACTION_MAXFEE;
 
 CTxMemPool mempool(::minRelayTxFeeRate);
 
-/**
- * Returns true if there are nRequired or more blocks of minVersion or above
- * in the last Consensus::Params::nMajorityWindow blocks, starting at pstart and going backwards.
- */
-static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams);
 static void CheckBlockIndex(const Consensus::Params& consensusParams);
 
 /** Constant stuff for coinbase transactions we create: */
@@ -102,10 +98,48 @@ const std::string strMessageMagic = "Dogecoin Signed Message:\n";
 // Internal stuff
 namespace {
 
+    static const int DEFAULT_SHADOWFORK_SNAPSHOT_WINDOW = 8192;
+    static const int SHADOWFORK_LAZY_ACTIVE_CHAIN_CHUNK = 256;
+
     bool IsShadowForkOptimizationEnabled(const CChainParams& params, const char* arg)
     {
         return params.GetConsensus(0).fShadowForkMode && GetBoolArg(arg, true);
     }
+
+    struct ShadowForkLazyBlockIndexState
+    {
+        bool enabled;
+        std::string source_chain;
+        int snapshot_tip_height;
+        int active_tip_height;
+        int eager_base_height;
+        bool fast_candidates;
+        std::unique_ptr<ShadowForkSnapshotReader> reader;
+        std::vector<ShadowForkActiveChainRecord> delta_records;
+
+        ShadowForkLazyBlockIndexState()
+            : enabled(false),
+              snapshot_tip_height(-1),
+              active_tip_height(-1),
+              eager_base_height(0),
+              fast_candidates(false)
+        {
+        }
+
+        void Reset()
+        {
+            enabled = false;
+            source_chain.clear();
+            snapshot_tip_height = -1;
+            active_tip_height = -1;
+            eager_base_height = 0;
+            fast_candidates = false;
+            reader.reset();
+            delta_records.clear();
+        }
+    };
+
+    ShadowForkLazyBlockIndexState g_shadowfork_lazy_block_index;
 
     struct CBlockIndexWorkComparator
     {
@@ -228,15 +262,32 @@ public:
 
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
 {
+    LOCK(cs_main);
+
     // Find the first block the caller has in the main chain
     BOOST_FOREACH(const uint256& hash, locator.vHave) {
+        CBlockIndex* pindex = NULL;
         BlockMap::iterator mi = mapBlockIndex.find(hash);
-        if (mi != mapBlockIndex.end())
+        if (mi != mapBlockIndex.end()) {
+            pindex = (*mi).second;
+        } else if (g_shadowfork_lazy_block_index.enabled) {
+            pindex = LookupBlockIndex(hash);
+        }
+
+        if (pindex != NULL)
         {
-            CBlockIndex* pindex = (*mi).second;
-            if (chain.Contains(pindex))
+            if (chain.Contains(pindex)) {
                 return pindex;
-            if (pindex->GetAncestor(chain.Height()) == chain.Tip()) {
+            }
+
+            if (g_shadowfork_lazy_block_index.enabled) {
+                CBlockIndex* pactive = LoadShadowForkActiveChainIndex(pindex->nHeight);
+                if (pactive != NULL && pactive->GetBlockHash() == pindex->GetBlockHash()) {
+                    return pindex;
+                }
+            }
+
+            if (pindex->nHeight <= chain.Height() && pindex->GetAncestor(chain.Height()) == chain.Tip()) {
                 return chain.Tip();
             }
         }
@@ -1188,8 +1239,12 @@ static bool ReadBlockOrHeader(T& block, const CDiskBlockPos& pos, const Consensu
         return error("%s: Deserialize or I/O error - %s at %s", __func__, e.what(), pos.ToString());
     }
 
+    // Shadowfork instant-mined blocks do not satisfy canonical PoW checks.
+    const bool fSkipShadowForkPow =
+        consensusParams.fShadowForkMode && GetBoolArg("-shadowforkinstantmining", true);
+
     // Check the header
-    if (fCheckPOW && !CheckAuxPowProofOfWork(block, consensusParams))
+    if (fCheckPOW && !fSkipShadowForkPow && !CheckAuxPowProofOfWork(block, consensusParams))
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
 
     return true;
@@ -1890,9 +1945,16 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // before the first had been spent.  Since those coinbases are sufficiently buried its no longer possible to create further
     // duplicate transactions descending from the known pairs either.
     // If we're on the known chain at height greater than where BIP34 activated, we can save the db accesses needed for the BIP30 check.
-    CBlockIndex *pindexBIP34height = pindex->pprev->GetAncestor(chainparams.GetConsensus(0).BIP34Height);
-    //Only continue to enforce if we're below BIP34 activation height or the block hash at that height doesn't correspond.
-    fEnforceBIP30 = fEnforceBIP30 && (!pindexBIP34height || !(pindexBIP34height->GetBlockHash() == chainparams.GetConsensus(0).BIP34Hash));
+    if (chainparams.GetConsensus(0).fShadowForkMode) {
+        // Shadow forks inherit an already-validated post-BIP34 chain and only
+        // append new local blocks. Avoid forcing a deep historical ancestor load
+        // just to prove the inherited chain reached the known BIP34 checkpoint.
+        fEnforceBIP30 = false;
+    } else {
+        CBlockIndex *pindexBIP34height = pindex->pprev->GetAncestor(chainparams.GetConsensus(0).BIP34Height);
+        //Only continue to enforce if we're below BIP34 activation height or the block hash at that height doesn't correspond.
+        fEnforceBIP30 = fEnforceBIP30 && (!pindexBIP34height || !(pindexBIP34height->GetBlockHash() == chainparams.GetConsensus(0).BIP34Hash));
+    }
 
     if (fEnforceBIP30) {
         for (const auto& tx : block.vtx) {
@@ -2800,10 +2862,10 @@ CBlockIndex* AddToBlockIndex(const CBlockHeader& block)
     pindexNew->nSequenceId = 0;
     BlockMap::iterator mi = mapBlockIndex.insert(std::make_pair(hash, pindexNew)).first;
     pindexNew->phashBlock = &((*mi).first);
-    BlockMap::iterator miPrev = mapBlockIndex.find(block.hashPrevBlock);
-    if (miPrev != mapBlockIndex.end())
+    CBlockIndex* pprev = LookupBlockIndex(block.hashPrevBlock);
+    if (pprev != NULL)
     {
-        pindexNew->pprev = (*miPrev).second;
+        pindexNew->pprev = pprev;
         pindexNew->nHeight = pindexNew->pprev->nHeight + 1;
         pindexNew->BuildSkip();
     }
@@ -3404,18 +3466,6 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     return true;
 }
 
-static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams)
-{
-    unsigned int nFound = 0;
-    for (int i = 0; i < consensusParams.nMajorityWindow && nFound < nRequired && pstart != NULL; i++)
-    {
-        if (pstart->GetBaseVersion() >= minVersion)
-            ++nFound;
-        pstart = pstart->pprev;
-    }
-    return (nFound >= nRequired);
-}
-
 bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock)
 {
     {
@@ -3676,7 +3726,468 @@ CBlockIndex * InsertBlockIndex(uint256 hash)
     return pindexNew;
 }
 
-bool static LoadBlockIndexDB(const CChainParams& chainparams)
+static std::vector<std::pair<int, CBlockIndex*> > GetBlockIndexByHeight()
+{
+    std::vector<std::pair<int, CBlockIndex*> > vSortedByHeight;
+    vSortedByHeight.reserve(mapBlockIndex.size());
+    BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
+    {
+        CBlockIndex* pindex = item.second;
+        vSortedByHeight.push_back(std::make_pair(pindex->nHeight, pindex));
+    }
+    sort(vSortedByHeight.begin(), vSortedByHeight.end());
+    return vSortedByHeight;
+}
+
+static void TrackLoadedBlockIndexEntry(CBlockIndex* pindex, bool fShadowForkFastCandidates, bool fBuildSkip = true)
+{
+    if (pindex->nTx > 0) {
+        if (pindex->pprev && !pindex->pprev->nChainTx) {
+            mapBlocksUnlinked.insert(std::make_pair(pindex->pprev, pindex));
+        }
+        if (!(pindex->nStatus & BLOCK_FAILED_MASK) && pindex->pprev && (pindex->pprev->nStatus & BLOCK_FAILED_MASK)) {
+            LogPrintf("Invalid Block %s.\n", pindex->GetBlockHash().ToString());
+            pindex->nStatus |= BLOCK_FAILED_CHILD;
+            setDirtyBlockIndex.insert(pindex);
+        }
+    }
+    if (!fShadowForkFastCandidates && pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && (pindex->nChainTx || pindex->pprev == NULL)) {
+        setBlockIndexCandidates.insert(pindex);
+    }
+    if (pindex->nStatus & BLOCK_FAILED_MASK && (!pindexBestInvalid || pindex->nChainWork > pindexBestInvalid->nChainWork)) {
+        pindexBestInvalid = pindex;
+    }
+    if (fBuildSkip && pindex->pprev) {
+        pindex->BuildSkip();
+    }
+    if (pindex->IsValid(BLOCK_VALID_TREE) && (pindexBestHeader == NULL || CBlockIndexWorkComparator()(pindexBestHeader, pindex))) {
+        pindexBestHeader = pindex;
+    }
+}
+
+static void LoadBlockTreeFlags()
+{
+    fHavePruned = false;
+    pblocktree->ReadFlag("prunedblockfiles", fHavePruned);
+    if (fHavePruned) {
+        LogPrintf("LoadBlockIndexDB(): Block files have previously been pruned\n");
+    }
+
+    bool fReindexing = false;
+    pblocktree->ReadReindexing(fReindexing);
+    fReindex |= fReindexing;
+
+    fTxIndex = false;
+    pblocktree->ReadFlag("txindex", fTxIndex);
+    LogPrintf("%s: transaction index %s\n", __func__, fTxIndex ? "enabled" : "disabled");
+}
+
+static bool LoadBlockFileInfoFromBlockTree()
+{
+    if (!pblocktree->ReadLastBlockFile(nLastBlockFile)) {
+        nLastBlockFile = 0;
+        vinfoBlockFile.clear();
+        vinfoBlockFile.resize(1);
+        return true;
+    }
+
+    vinfoBlockFile.clear();
+    vinfoBlockFile.resize(nLastBlockFile + 1);
+    LogPrintf("%s: last block file = %i\n", __func__, nLastBlockFile);
+    for (int nFile = 0; nFile <= nLastBlockFile; nFile++) {
+        pblocktree->ReadBlockFileInfo(nFile, vinfoBlockFile[nFile]);
+    }
+    if (!vinfoBlockFile.empty()) {
+        LogPrintf("%s: last block file info: %s\n", __func__, vinfoBlockFile[nLastBlockFile].ToString());
+    }
+    for (int nFile = nLastBlockFile + 1; true; nFile++) {
+        CBlockFileInfo info;
+        if (pblocktree->ReadBlockFileInfo(nFile, info)) {
+            vinfoBlockFile.push_back(info);
+        } else {
+            break;
+        }
+    }
+
+    return true;
+}
+
+static int GetShadowForkSnapshotWindowSize()
+{
+    const int configured = GetArg("-shadowforksnapshotwindow", DEFAULT_SHADOWFORK_SNAPSHOT_WINDOW);
+    return std::max(1, configured);
+}
+
+static bool GetShadowForkActiveChainRecordAtHeight(int height, ShadowForkActiveChainRecord* record, std::string* error)
+{
+    if (!g_shadowfork_lazy_block_index.enabled) {
+        return false;
+    }
+    if (height < 0 || height > g_shadowfork_lazy_block_index.active_tip_height) {
+        return false;
+    }
+    if (height <= g_shadowfork_lazy_block_index.snapshot_tip_height) {
+        return g_shadowfork_lazy_block_index.reader->ReadActiveChainRecordAtHeight(height, *record, error);
+    }
+
+    const size_t delta_index = static_cast<size_t>(height - g_shadowfork_lazy_block_index.snapshot_tip_height - 1);
+    if (delta_index >= g_shadowfork_lazy_block_index.delta_records.size()) {
+        return false;
+    }
+    *record = g_shadowfork_lazy_block_index.delta_records[delta_index];
+    return true;
+}
+
+static bool PopulateShadowForkActiveChainEntry(int height, const ShadowForkActiveChainRecord& record, CBlockIndex* pprev, bool fShadowForkFastCandidates, CBlockIndex** ppindex)
+{
+    CDiskBlockIndex diskindex;
+    if (!pblocktree->ReadBlockIndex(record.block_hash, diskindex)) {
+        LogPrintf("PopulateShadowForkActiveChainEntry(): failed to read blocks/index entry for %s at height %d\n",
+            record.block_hash.ToString(), height);
+        return false;
+    }
+    if (diskindex.nHeight != height) {
+        LogPrintf("PopulateShadowForkActiveChainEntry(): height mismatch for %s (%d != %d)\n",
+            record.block_hash.ToString(), diskindex.nHeight, height);
+        return false;
+    }
+    if ((height == 0 && !diskindex.hashPrev.IsNull()) ||
+        (height > 0 && pprev != NULL && diskindex.hashPrev != pprev->GetBlockHash())) {
+        LogPrintf("PopulateShadowForkActiveChainEntry(): parent mismatch for %s at height %d\n",
+            record.block_hash.ToString(), height);
+        return false;
+    }
+
+    CBlockIndex* pindex = InsertBlockIndex(record.block_hash);
+    pindex->pprev = pprev;
+    pindex->nHeight = diskindex.nHeight;
+    pindex->nFile = diskindex.nFile;
+    pindex->nDataPos = diskindex.nDataPos;
+    pindex->nUndoPos = diskindex.nUndoPos;
+    pindex->nVersion = diskindex.nVersion;
+    pindex->hashMerkleRoot = diskindex.hashMerkleRoot;
+    pindex->nTime = diskindex.nTime;
+    pindex->nBits = diskindex.nBits;
+    pindex->nNonce = diskindex.nNonce;
+    pindex->nStatus = diskindex.nStatus;
+    pindex->nTx = diskindex.nTx;
+    pindex->nChainWork = UintToArith256(record.chain_work);
+    pindex->nChainTx = record.chain_tx_count;
+    pindex->nTimeMax = record.time_max;
+
+    // Lazy shadowfork snapshot loading must not recurse through BuildSkip(),
+    // because missing ancestors are populated on demand and recursive backfill
+    // here can blow the stack.
+    TrackLoadedBlockIndexEntry(pindex, fShadowForkFastCandidates, false);
+    *ppindex = pindex;
+    return true;
+}
+
+static bool TryLoadShadowForkActiveChainSegment(int height, bool fShadowForkFastCandidates)
+{
+    AssertLockHeld(cs_main);
+
+    if (!g_shadowfork_lazy_block_index.enabled || height < 0 || height > g_shadowfork_lazy_block_index.active_tip_height) {
+        return false;
+    }
+
+    std::string snapshot_error;
+    ShadowForkActiveChainRecord height_record;
+    if (!GetShadowForkActiveChainRecordAtHeight(height, &height_record, &snapshot_error)) {
+        LogPrintf("TryLoadShadowForkActiveChainSegment(): failed to read snapshot height %d: %s\n", height, snapshot_error);
+        return false;
+    }
+
+    BlockMap::iterator existing_tip = mapBlockIndex.find(height_record.block_hash);
+    if (existing_tip != mapBlockIndex.end()) {
+        return true;
+    }
+
+    int start = height;
+    CBlockIndex* pprev = NULL;
+    while (start > 0) {
+        ShadowForkActiveChainRecord prev_record;
+        if (!GetShadowForkActiveChainRecordAtHeight(start - 1, &prev_record, &snapshot_error)) {
+            LogPrintf("TryLoadShadowForkActiveChainSegment(): failed to read snapshot height %d: %s\n", start - 1, snapshot_error);
+            return false;
+        }
+
+        BlockMap::iterator prev_it = mapBlockIndex.find(prev_record.block_hash);
+        if (prev_it != mapBlockIndex.end()) {
+            pprev = prev_it->second;
+            break;
+        }
+
+        if (height - start + 1 >= SHADOWFORK_LAZY_ACTIVE_CHAIN_CHUNK) {
+            break;
+        }
+        --start;
+    }
+
+    for (int cursor = start; cursor <= height; ++cursor) {
+        ShadowForkActiveChainRecord record;
+        if (!GetShadowForkActiveChainRecordAtHeight(cursor, &record, &snapshot_error)) {
+            LogPrintf("TryLoadShadowForkActiveChainSegment(): failed to read snapshot height %d: %s\n", cursor, snapshot_error);
+            return false;
+        }
+
+        BlockMap::iterator it = mapBlockIndex.find(record.block_hash);
+        if (it != mapBlockIndex.end()) {
+            pprev = it->second;
+            continue;
+        }
+
+        CBlockIndex* pindex = NULL;
+        if (!PopulateShadowForkActiveChainEntry(cursor, record, pprev, fShadowForkFastCandidates, &pindex)) {
+            return false;
+        }
+        pprev = pindex;
+    }
+
+    return true;
+}
+
+CBlockIndex* LoadShadowForkActiveChainIndex(int nHeight)
+{
+    AssertLockHeld(cs_main);
+
+    if (!g_shadowfork_lazy_block_index.enabled) {
+        return NULL;
+    }
+    if (!TryLoadShadowForkActiveChainSegment(nHeight, true)) {
+        return NULL;
+    }
+
+    std::string snapshot_error;
+    ShadowForkActiveChainRecord record;
+    if (!GetShadowForkActiveChainRecordAtHeight(nHeight, &record, &snapshot_error)) {
+        return NULL;
+    }
+    BlockMap::iterator it = mapBlockIndex.find(record.block_hash);
+    return it == mapBlockIndex.end() ? NULL : it->second;
+}
+
+CBlockIndex* LookupBlockIndex(const uint256& hash)
+{
+    AssertLockHeld(cs_main);
+
+    BlockMap::iterator it = mapBlockIndex.find(hash);
+    if (it != mapBlockIndex.end()) {
+        return it->second;
+    }
+    if (!g_shadowfork_lazy_block_index.enabled) {
+        return NULL;
+    }
+
+    CDiskBlockIndex diskindex;
+    if (!pblocktree->ReadBlockIndex(hash, diskindex)) {
+        return NULL;
+    }
+
+    ShadowForkActiveChainRecord record;
+    std::string snapshot_error;
+    if (!GetShadowForkActiveChainRecordAtHeight(diskindex.nHeight, &record, &snapshot_error)) {
+        return NULL;
+    }
+    if (record.block_hash != hash) {
+        return NULL;
+    }
+    if (!TryLoadShadowForkActiveChainSegment(diskindex.nHeight, true)) {
+        return NULL;
+    }
+
+    it = mapBlockIndex.find(hash);
+    return it == mapBlockIndex.end() ? NULL : it->second;
+}
+
+static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
+{
+    const bool fShadowForkFastCandidates =
+        IsShadowForkOptimizationEnabled(chainparams, "-shadowforkfastblockindexcandidates");
+
+    if (!chainparams.GetConsensus(0).fShadowForkMode || !GetBoolArg("-shadowforkusesnapshot", true)) {
+        return false;
+    }
+
+    bool fReindexing = false;
+    pblocktree->ReadReindexing(fReindexing);
+    if (fReindexing) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot disabled because blocks/index is mid-reindex\n");
+        return false;
+    }
+
+    const std::string source_chain = GetShadowForkSnapshotSourceChain(chainparams);
+    const uint256 best_block = pcoinsTip->GetBestBlock();
+    if (best_block.IsNull()) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot disabled because chainstate best block is null\n");
+        return false;
+    }
+
+    ShadowForkSnapshotReader reader;
+    ShadowForkSnapshotMetadata metadata;
+    std::string snapshot_error;
+    if (!reader.Open(source_chain, &snapshot_error)) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot unavailable: %s; falling back to blocks/index scan\n", snapshot_error);
+        return false;
+    }
+    if (!reader.ReadMetadata(metadata, &snapshot_error)) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot metadata invalid: %s; falling back to blocks/index scan\n", snapshot_error);
+        return false;
+    }
+    if (metadata.source_chain != source_chain) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot source mismatch (%s != %s); falling back to blocks/index scan\n",
+            metadata.source_chain, source_chain);
+        return false;
+    }
+    if (metadata.genesis_hash != chainparams.GetConsensus(0).hashGenesisBlock) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot genesis mismatch; falling back to blocks/index scan\n");
+        return false;
+    }
+    if (metadata.block_count == 0 || metadata.active_tip_hash.IsNull() || metadata.active_tip_height < 0) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot metadata is incomplete; falling back to blocks/index scan\n");
+        return false;
+    }
+    if (metadata.block_count != static_cast<uint64_t>(metadata.active_tip_height) + 1) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot height/count mismatch; falling back to blocks/index scan\n");
+        return false;
+    }
+    if (metadata.block_file_info.size() < static_cast<size_t>(metadata.last_block_file + 1)) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot block-file metadata is inconsistent; falling back to blocks/index scan\n");
+        return false;
+    }
+
+    ShadowForkActiveChainRecord snapshot_tip_record;
+    if (!reader.ReadActiveChainRecordAtHeight(metadata.active_tip_height, snapshot_tip_record, &snapshot_error)) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip read failed: %s; falling back to blocks/index scan\n", snapshot_error);
+        return false;
+    }
+    if (snapshot_tip_record.block_hash != metadata.active_tip_hash) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip hash mismatch; falling back to blocks/index scan\n");
+        return false;
+    }
+
+    const int64_t nSnapshotStart = GetTimeMillis();
+    fHavePruned = metadata.have_pruned;
+    fTxIndex = metadata.tx_index;
+    nLastBlockFile = metadata.last_block_file;
+    vinfoBlockFile = metadata.block_file_info;
+    if (fHavePruned) {
+        LogPrintf("LoadBlockIndexDB(): Block files have previously been pruned\n");
+    }
+    LogPrintf("%s: transaction index %s\n", __func__, fTxIndex ? "enabled" : "disabled");
+    if (!vinfoBlockFile.empty()) {
+        LogPrintf("%s: last block file = %i\n", __func__, nLastBlockFile);
+        LogPrintf("%s: last block file info: %s\n", __func__, vinfoBlockFile[nLastBlockFile].ToString());
+    }
+
+    std::vector<CDiskBlockIndex> vDeltaBlocks;
+    if (best_block != metadata.active_tip_hash) {
+        uint256 cursor = best_block;
+        while (cursor != metadata.active_tip_hash) {
+            CDiskBlockIndex diskindex;
+            if (!pblocktree->ReadBlockIndex(cursor, diskindex)) {
+                LogPrintf("LoadBlockIndexDB(): shadowfork snapshot delta lookup failed at %s; falling back to blocks/index scan\n",
+                    cursor.ToString());
+                return false;
+            }
+            if (diskindex.nHeight <= metadata.active_tip_height) {
+                LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip is not an ancestor of current best block; falling back to blocks/index scan\n");
+                return false;
+            }
+            vDeltaBlocks.push_back(diskindex);
+            cursor = diskindex.hashPrev;
+            if (vDeltaBlocks.size() > 100000) {
+                LogPrintf("LoadBlockIndexDB(): shadowfork snapshot delta exceeded 100000 blocks; falling back to blocks/index scan\n");
+                return false;
+            }
+        }
+
+        std::reverse(vDeltaBlocks.begin(), vDeltaBlocks.end());
+        LoadBlockFileInfoFromBlockTree();
+        LoadBlockTreeFlags();
+    }
+
+    g_shadowfork_lazy_block_index.Reset();
+    g_shadowfork_lazy_block_index.source_chain = source_chain;
+    g_shadowfork_lazy_block_index.snapshot_tip_height = metadata.active_tip_height;
+    g_shadowfork_lazy_block_index.active_tip_height = metadata.active_tip_height + vDeltaBlocks.size();
+    g_shadowfork_lazy_block_index.eager_base_height = std::max(0, g_shadowfork_lazy_block_index.active_tip_height - GetShadowForkSnapshotWindowSize() + 1);
+    g_shadowfork_lazy_block_index.fast_candidates = fShadowForkFastCandidates;
+    g_shadowfork_lazy_block_index.reader.reset(new ShadowForkSnapshotReader());
+    if (!g_shadowfork_lazy_block_index.reader->Open(source_chain, &snapshot_error) ||
+        !g_shadowfork_lazy_block_index.reader->ReadMetadata(metadata, &snapshot_error)) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot reopen failed: %s; falling back to blocks/index scan\n", snapshot_error);
+        g_shadowfork_lazy_block_index.Reset();
+        return false;
+    }
+
+    arith_uint256 chain_work = UintToArith256(snapshot_tip_record.chain_work);
+    uint32_t chain_tx_count = snapshot_tip_record.chain_tx_count;
+    uint32_t time_max = snapshot_tip_record.time_max;
+    for (std::vector<CDiskBlockIndex>::const_iterator it = vDeltaBlocks.begin(); it != vDeltaBlocks.end(); ++it) {
+        ShadowForkActiveChainRecord delta_record;
+        delta_record.block_hash = it->GetBlockHash();
+        chain_work += GetBlockProof(*it);
+        delta_record.chain_work = ArithToUint256(chain_work);
+        if (it->nTx > 0) {
+            chain_tx_count += it->nTx;
+        }
+        delta_record.chain_tx_count = chain_tx_count;
+        time_max = std::max<uint32_t>(time_max, it->nTime);
+        delta_record.time_max = time_max;
+        g_shadowfork_lazy_block_index.delta_records.push_back(delta_record);
+    }
+    g_shadowfork_lazy_block_index.enabled = true;
+
+    // Keep genesis materialized even in lazy mode. Later startup checks assume
+    // the loaded block index contains the network genesis hash.
+    if (!TryLoadShadowForkActiveChainSegment(0, fShadowForkFastCandidates)) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot failed to materialize genesis; falling back to blocks/index scan\n");
+        g_shadowfork_lazy_block_index.Reset();
+        return false;
+    }
+
+    for (int chunk_end = g_shadowfork_lazy_block_index.eager_base_height;
+         chunk_end <= g_shadowfork_lazy_block_index.active_tip_height;
+         chunk_end += SHADOWFORK_LAZY_ACTIVE_CHAIN_CHUNK) {
+        const int target_height = std::min(g_shadowfork_lazy_block_index.active_tip_height,
+            chunk_end + SHADOWFORK_LAZY_ACTIVE_CHAIN_CHUNK - 1);
+        if (!TryLoadShadowForkActiveChainSegment(target_height, fShadowForkFastCandidates)) {
+            LogPrintf("LoadBlockIndexDB(): shadowfork snapshot eager load failed at height %d; falling back to blocks/index scan\n",
+                target_height);
+            g_shadowfork_lazy_block_index.Reset();
+            return false;
+        }
+    }
+
+    CBlockIndex* pbest = LookupBlockIndex(best_block);
+    if (pbest == NULL) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot load did not reconstruct the current best block; falling back to blocks/index scan\n");
+        g_shadowfork_lazy_block_index.Reset();
+        return false;
+    }
+    chainActive.SetTipWindow(pbest, g_shadowfork_lazy_block_index.eager_base_height);
+
+    if (fShadowForkFastCandidates) {
+        setBlockIndexCandidates.insert(chainActive.Tip());
+        LogPrintf("%s: shadow fork snapshot fast candidates enabled; inserted active tip only\n", __func__);
+    } else {
+        PruneBlockIndexCandidates();
+    }
+
+    LogPrintf("%s: loaded shadowfork snapshot for %s in %dms (window_start=%d loaded=%d delta=%u shadowfork_fast_candidates=%d); hashBestChain=%s height=%d date=%s progress=%f\n",
+        __func__, source_chain, GetTimeMillis() - nSnapshotStart,
+        g_shadowfork_lazy_block_index.eager_base_height,
+        chainActive.Height() - g_shadowfork_lazy_block_index.eager_base_height + 1,
+        static_cast<unsigned int>(vDeltaBlocks.size()), fShadowForkFastCandidates,
+        chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(),
+        DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
+        GuessVerificationProgress(chainparams.TxData(), chainActive.Tip()));
+
+    return true;
+}
+
+bool static LoadBlockIndexDBFromLevelDB(const CChainParams& chainparams)
 {
     const int64_t nLoadStart = GetTimeMillis();
     const bool fShadowForkFastCandidates =
@@ -3691,14 +4202,7 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
 
     // Calculate nChainWork
     const int64_t nSortStart = GetTimeMillis();
-    std::vector<std::pair<int, CBlockIndex*> > vSortedByHeight;
-    vSortedByHeight.reserve(mapBlockIndex.size());
-    BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
-    {
-        CBlockIndex* pindex = item.second;
-        vSortedByHeight.push_back(std::make_pair(pindex->nHeight, pindex));
-    }
-    sort(vSortedByHeight.begin(), vSortedByHeight.end());
+    std::vector<std::pair<int, CBlockIndex*> > vSortedByHeight = GetBlockIndexByHeight();
     LogPrintf("%s: sorted block index by height in %dms\n",
         __func__, GetTimeMillis() - nSortStart);
 
@@ -3740,21 +4244,7 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
         __func__, GetTimeMillis() - nPostProcessStart, fShadowForkFastCandidates);
 
     // Load block file info
-    pblocktree->ReadLastBlockFile(nLastBlockFile);
-    vinfoBlockFile.resize(nLastBlockFile + 1);
-    LogPrintf("%s: last block file = %i\n", __func__, nLastBlockFile);
-    for (int nFile = 0; nFile <= nLastBlockFile; nFile++) {
-        pblocktree->ReadBlockFileInfo(nFile, vinfoBlockFile[nFile]);
-    }
-    LogPrintf("%s: last block file info: %s\n", __func__, vinfoBlockFile[nLastBlockFile].ToString());
-    for (int nFile = nLastBlockFile + 1; true; nFile++) {
-        CBlockFileInfo info;
-        if (pblocktree->ReadBlockFileInfo(nFile, info)) {
-            vinfoBlockFile.push_back(info);
-        } else {
-            break;
-        }
-    }
+    LoadBlockFileInfoFromBlockTree();
 
     // Check presence of blk files
     LogPrintf("Checking all blk files are present...\n");
@@ -3774,19 +4264,7 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
         }
     }
 
-    // Check whether we have ever pruned block & undo files
-    pblocktree->ReadFlag("prunedblockfiles", fHavePruned);
-    if (fHavePruned)
-        LogPrintf("LoadBlockIndexDB(): Block files have previously been pruned\n");
-
-    // Check whether we need to continue reindexing
-    bool fReindexing = false;
-    pblocktree->ReadReindexing(fReindexing);
-    fReindex |= fReindexing;
-
-    // Check whether we have a transaction index
-    pblocktree->ReadFlag("txindex", fTxIndex);
-    LogPrintf("%s: transaction index %s\n", __func__, fTxIndex ? "enabled" : "disabled");
+    LoadBlockTreeFlags();
 
     // Load pointer to end of best chain
     BlockMap::iterator it = mapBlockIndex.find(pcoinsTip->GetBestBlock());
@@ -3807,6 +4285,16 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
         GuessVerificationProgress(chainparams.TxData(), chainActive.Tip()));
 
     return true;
+}
+
+bool static LoadBlockIndexDB(const CChainParams& chainparams)
+{
+    if (TryLoadShadowForkSnapshot(chainparams)) {
+        return true;
+    }
+
+    UnloadBlockIndex();
+    return LoadBlockIndexDBFromLevelDB(chainparams);
 }
 
 CVerifyDB::CVerifyDB()
@@ -4029,6 +4517,7 @@ void UnloadBlockIndex()
     }
     mapBlockIndex.clear();
     fHavePruned = false;
+    g_shadowfork_lazy_block_index.Reset();
 }
 
 bool LoadBlockIndex(const CChainParams& chainparams)
@@ -4036,6 +4525,72 @@ bool LoadBlockIndex(const CChainParams& chainparams)
     // Load block index from databases
     if (!fReindex && !LoadBlockIndexDB(chainparams))
         return false;
+    return true;
+}
+
+bool BuildShadowForkBlockIndexSnapshot(const CChainParams& chainparams)
+{
+    LOCK(cs_main);
+
+    if (chainparams.GetConsensus(0).fShadowForkMode) {
+        return error("%s: shadowfork snapshots must be built from a source main/test datadir", __func__);
+    }
+    if (chainActive.Tip() == NULL) {
+        return error("%s: chainActive tip is null", __func__);
+    }
+
+    const std::string source_chain = GetShadowForkSnapshotSourceChain(chainparams);
+    if (source_chain != "main" && source_chain != "test") {
+        return error("%s: unsupported shadowfork snapshot source chain %s", __func__, source_chain);
+    }
+
+    ShadowForkSnapshotMetadata metadata;
+    metadata.source_chain = source_chain;
+    metadata.genesis_hash = chainparams.GetConsensus(0).hashGenesisBlock;
+    metadata.active_tip_hash = chainActive.Tip()->GetBlockHash();
+    metadata.active_tip_height = chainActive.Height();
+    metadata.tx_index = fTxIndex;
+    metadata.have_pruned = fHavePruned;
+    metadata.last_block_file = nLastBlockFile;
+    metadata.block_count = static_cast<uint64_t>(chainActive.Height()) + 1;
+    metadata.block_file_info = vinfoBlockFile;
+
+    const int64_t nSnapshotStart = GetTimeMillis();
+    ShadowForkSnapshotWriter writer;
+    std::string snapshot_error;
+    if (!writer.Open(source_chain, &snapshot_error)) {
+        return error("%s: %s", __func__, snapshot_error);
+    }
+    if (!writer.WriteMetadata(metadata, &snapshot_error)) {
+        return error("%s: %s", __func__, snapshot_error);
+    }
+
+    for (int height = 0; height <= chainActive.Height(); ++height) {
+        const CBlockIndex* pindex = chainActive[height];
+        if (pindex == NULL) {
+            return error("%s: active chain entry at height %d is null", __func__, height);
+        }
+
+        ShadowForkActiveChainRecord record;
+        record.block_hash = pindex->GetBlockHash();
+        record.chain_work = ArithToUint256(pindex->nChainWork);
+        record.chain_tx_count = pindex->nChainTx;
+        record.time_max = pindex->nTimeMax;
+
+        if (!writer.WriteActiveChainRecord(record, &snapshot_error)) {
+            return error("%s: %s", __func__, snapshot_error);
+        }
+    }
+
+    if (!writer.Commit(&snapshot_error)) {
+        return error("%s: %s", __func__, snapshot_error);
+    }
+
+    LogPrintf("%s: wrote shadowfork snapshot for %s with %u active-chain entries to %s in %dms\n",
+        __func__, source_chain, (unsigned int)metadata.block_count,
+        GetShadowForkSnapshotPath(source_chain).string(),
+        GetTimeMillis() - nSnapshotStart);
+
     return true;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -89,6 +89,7 @@ CAmount maxTxFee = DEFAULT_TRANSACTION_MAXFEE;
 CTxMemPool mempool(::minRelayTxFeeRate);
 
 static void CheckBlockIndex(const Consensus::Params& consensusParams);
+static bool EnsureShadowForkActiveChainParentLoaded(CBlockIndex* pindex, bool fShadowForkFastCandidates);
 
 /** Constant stuff for coinbase transactions we create: */
 CScript COINBASE_FLAGS;
@@ -2363,6 +2364,11 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
 {
     CBlockIndex *pindexDelete = chainActive.Tip();
     assert(pindexDelete);
+    if (pindexDelete->pprev == NULL && pindexDelete->nHeight > 0 &&
+        !EnsureShadowForkActiveChainParentLoaded(pindexDelete, true)) {
+        return error("DisconnectTip(): failed to load parent for %s at height %d",
+            pindexDelete->GetBlockHash().ToString(), pindexDelete->nHeight);
+    }
     // Read block from disk.
     CBlock block;
     if (!ReadBlockFromDisk(block, pindexDelete, chainparams.GetConsensus(chainActive.Height())))
@@ -3897,6 +3903,8 @@ static bool TryLoadShadowForkActiveChainSegment(int height, bool fShadowForkFast
 
 static bool GetShadowForkActiveChainRecordAtHeight(int height, ShadowForkActiveChainRecord* record, std::string* error)
 {
+    AssertLockHeld(cs_main);
+
     if (!g_shadowfork_lazy_block_index.enabled) {
         return false;
     }
@@ -4023,7 +4031,6 @@ static bool EnsureShadowForkActiveChainParentLoaded(CBlockIndex* pindex, bool fS
     }
 
     pindex->pprev = prev_it->second;
-    pindex->BuildSkip();
     return true;
 }
 
@@ -4129,25 +4136,6 @@ CBlockIndex* LookupBlockIndex(const uint256& hash)
         return NULL;
     }
 
-    if (Params().GetConsensus(0).fShadowForkMode &&
-        GetBoolArg("-shadowforkstartupcut", true) &&
-        g_shadowfork_lazy_block_index.active_tip_height == g_shadowfork_lazy_block_index.eager_base_height) {
-        ShadowForkActiveChainRecord tip_record;
-        std::string snapshot_error;
-        if (GetShadowForkActiveChainRecordAtHeight(
-                g_shadowfork_lazy_block_index.active_tip_height,
-                &tip_record,
-                &snapshot_error) &&
-            tip_record.block_hash == hash) {
-            if (!TryLoadShadowForkActiveChainSegment(g_shadowfork_lazy_block_index.active_tip_height, true)) {
-                return NULL;
-            }
-            it = mapBlockIndex.find(hash);
-            return it == mapBlockIndex.end() ? NULL : it->second;
-        }
-        return NULL;
-    }
-
     CDiskBlockIndex diskindex;
     if (!pblocktree->ReadBlockIndex(hash, diskindex)) {
         return NULL;
@@ -4210,6 +4198,7 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
     if (!chainparams.GetConsensus(0).fShadowForkMode || !GetBoolArg("-shadowforkusesnapshot", true)) {
         return false;
     }
+    LOCK(cs_main);
 
     bool fReindexing = false;
     pblocktree->ReadReindexing(fReindexing);
@@ -4261,7 +4250,6 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
     uint256 best_block = chainstate_best_block;
     int startup_cut_height = -1;
     ShadowForkActiveChainRecord startup_cut_record;
-    bool have_startup_cut_record = false;
     if (GetBoolArg("-shadowforkstartupcut", true) && IsArgSet("-shadowfork")) {
         const int64_t requested_height = GetArg("-shadowfork", -1);
         if (requested_height >= 0 && requested_height <= metadata.active_tip_height) {
@@ -4270,29 +4258,33 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
                     static_cast<int>(requested_height), snapshot_error);
                 return false;
             }
-            best_block = startup_cut_record.block_hash;
             startup_cut_height = static_cast<int>(requested_height);
-            have_startup_cut_record = true;
-            LogPrintf("LoadBlockIndexDB(): shadowfork startup cut height %d is covered by snapshot tip height %d; ignoring chainstate best %s during lazy block-index load\n",
+            LogPrintf("LoadBlockIndexDB(): shadowfork startup cut height %d is covered by snapshot tip height %d; loading chainstate best %s before rollback\n",
                 startup_cut_height, metadata.active_tip_height, chainstate_best_block.ToString());
         }
     }
 
     ShadowForkActiveChainRecord snapshot_tip_record;
-    if (have_startup_cut_record) {
-        snapshot_tip_record = startup_cut_record;
-    } else {
-        if (!reader.ReadActiveChainRecordAtHeight(metadata.active_tip_height, snapshot_tip_record, &snapshot_error)) {
-            LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip read failed: %s; falling back to blocks/index scan\n", snapshot_error);
-            return false;
-        }
-        if (snapshot_tip_record.block_hash != metadata.active_tip_hash) {
-            LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip hash mismatch; falling back to blocks/index scan\n");
-            return false;
-        }
+    if (!reader.ReadActiveChainRecordAtHeight(metadata.active_tip_height, snapshot_tip_record, &snapshot_error)) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip read failed: %s; falling back to blocks/index scan\n", snapshot_error);
+        return false;
+    }
+    if (snapshot_tip_record.block_hash != metadata.active_tip_hash) {
+        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip hash mismatch; falling back to blocks/index scan\n");
+        return false;
     }
 
     const int64_t nSnapshotStart = GetTimeMillis();
+    const bool oldHavePruned = fHavePruned;
+    const bool oldTxIndex = fTxIndex;
+    const int oldLastBlockFile = nLastBlockFile;
+    const std::vector<CBlockFileInfo> oldBlockFileInfo = vinfoBlockFile;
+    const auto restore_snapshot_globals = [&]() {
+        fHavePruned = oldHavePruned;
+        fTxIndex = oldTxIndex;
+        nLastBlockFile = oldLastBlockFile;
+        vinfoBlockFile = oldBlockFileInfo;
+    };
     fHavePruned = metadata.have_pruned;
     fTxIndex = metadata.tx_index;
     nLastBlockFile = metadata.last_block_file;
@@ -4307,23 +4299,26 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
     }
 
     std::vector<CDiskBlockIndex> vDeltaBlocks;
-    if (startup_cut_height < 0 && best_block != metadata.active_tip_hash) {
+    if (best_block != metadata.active_tip_hash) {
         uint256 cursor = best_block;
         while (cursor != metadata.active_tip_hash) {
             CDiskBlockIndex diskindex;
             if (!pblocktree->ReadBlockIndex(cursor, diskindex)) {
                 LogPrintf("LoadBlockIndexDB(): shadowfork snapshot delta lookup failed at %s; falling back to blocks/index scan\n",
                     cursor.ToString());
+                restore_snapshot_globals();
                 return false;
             }
             if (diskindex.nHeight <= metadata.active_tip_height) {
                 LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip is not an ancestor of current best block; falling back to blocks/index scan\n");
+                restore_snapshot_globals();
                 return false;
             }
             vDeltaBlocks.push_back(diskindex);
             cursor = diskindex.hashPrev;
             if (vDeltaBlocks.size() > 100000) {
                 LogPrintf("LoadBlockIndexDB(): shadowfork snapshot delta exceeded 100000 blocks; falling back to blocks/index scan\n");
+                restore_snapshot_globals();
                 return false;
             }
         }
@@ -4336,18 +4331,16 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
     g_shadowfork_lazy_block_index.Reset();
     g_shadowfork_lazy_block_index.source_chain = source_chain;
     g_shadowfork_lazy_block_index.snapshot_tip_height = metadata.active_tip_height;
-    g_shadowfork_lazy_block_index.active_tip_height = startup_cut_height >= 0
-        ? startup_cut_height
-        : metadata.active_tip_height + vDeltaBlocks.size();
-    g_shadowfork_lazy_block_index.eager_base_height = startup_cut_height >= 0
-        ? startup_cut_height
-        : std::max(0, g_shadowfork_lazy_block_index.active_tip_height - GetShadowForkSnapshotWindowSize() + 1);
+    g_shadowfork_lazy_block_index.active_tip_height = metadata.active_tip_height + vDeltaBlocks.size();
+    g_shadowfork_lazy_block_index.eager_base_height =
+        std::max(0, g_shadowfork_lazy_block_index.active_tip_height - GetShadowForkSnapshotWindowSize() + 1);
     g_shadowfork_lazy_block_index.fast_candidates = fShadowForkFastCandidates;
     g_shadowfork_lazy_block_index.reader.reset(new ShadowForkSnapshotReader());
     if (!g_shadowfork_lazy_block_index.reader->Open(source_chain, &snapshot_error) ||
         !g_shadowfork_lazy_block_index.reader->ReadMetadata(metadata, &snapshot_error)) {
         LogPrintf("LoadBlockIndexDB(): shadowfork snapshot reopen failed: %s; falling back to blocks/index scan\n", snapshot_error);
         g_shadowfork_lazy_block_index.Reset();
+        restore_snapshot_globals();
         return false;
     }
 
@@ -4374,6 +4367,7 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
     if (!TryLoadShadowForkActiveChainSegment(0, fShadowForkFastCandidates)) {
         LogPrintf("LoadBlockIndexDB(): shadowfork snapshot failed to materialize genesis; falling back to blocks/index scan\n");
         g_shadowfork_lazy_block_index.Reset();
+        restore_snapshot_globals();
         return false;
     }
 
@@ -4386,6 +4380,7 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
             LogPrintf("LoadBlockIndexDB(): shadowfork snapshot eager load failed at height %d; falling back to blocks/index scan\n",
                 target_height);
             g_shadowfork_lazy_block_index.Reset();
+            restore_snapshot_globals();
             return false;
         }
     }
@@ -4394,6 +4389,7 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
     if (pbest == NULL) {
         LogPrintf("LoadBlockIndexDB(): shadowfork snapshot load did not reconstruct the current best block; falling back to blocks/index scan\n");
         g_shadowfork_lazy_block_index.Reset();
+        restore_snapshot_globals();
         return false;
     }
     chainActive.SetTipWindow(pbest, g_shadowfork_lazy_block_index.eager_base_height);
@@ -4794,14 +4790,43 @@ bool ApplyShadowForkStartupCut(const CChainParams& chainparams)
     const int loaded_height = chainActive.Height();
     const uint256 loaded_hash = chainActive.Tip()->GetBlockHash();
     const uint256 old_coins_best = pcoinsTip->GetBestBlock();
-    if (requested_height == loaded_height && old_coins_best == target->GetBlockHash()) {
+    if (requested_height == loaded_height) {
+        if (old_coins_best != target->GetBlockHash()) {
+            return error("%s: active tip already at requested height %d but coins best is %s, expected %s; refusing unsafe shadow fork cut",
+                __func__, requested_height, old_coins_best.ToString(), target->GetBlockHash().ToString());
+        }
         LogPrintf("%s: loaded source tip already matches requested shadow fork height %d (%s)\n",
             __func__, requested_height, target->GetBlockHash().ToString());
         return true;
     }
 
-    chainActive.SetTipWindow(target, target->nHeight);
-    pcoinsTip->SetBestBlock(target->GetBlockHash());
+    CValidationState state;
+    int disconnected = 0;
+    while (chainActive.Height() > requested_height) {
+        if (!DisconnectTip(state, chainparams, true)) {
+            mempool.removeForReorg(pcoinsTip, chainActive.Height() + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
+            return error("%s: failed to disconnect inherited source block while rolling back from height %d to %d",
+                __func__, loaded_height, requested_height);
+        }
+        ++disconnected;
+    }
+
+    target = chainActive.Tip();
+    if (target == NULL || target->nHeight != requested_height) {
+        return error("%s: rollback ended at height %d, expected %d",
+            __func__, target ? target->nHeight : -1, requested_height);
+    }
+    if (pcoinsTip->GetBestBlock() != target->GetBlockHash()) {
+        return error("%s: rollback ended with coins best %s, expected %s",
+            __func__, pcoinsTip->GetBestBlock().ToString(), target->GetBlockHash().ToString());
+    }
+    if (disconnected > 0) {
+        mempool.removeForReorg(pcoinsTip, chainActive.Height() + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
+    }
+    if (!FlushStateToDisk(state, FLUSH_STATE_ALWAYS)) {
+        return error("%s: failed to flush chainstate after shadow fork rollback", __func__);
+    }
+
     pindexBestHeader = target;
     if (g_shadowfork_lazy_block_index.enabled) {
         // The prepared-volume snapshot may have been loaded at the source tip.
@@ -4821,9 +4846,9 @@ bool ApplyShadowForkStartupCut(const CChainParams& chainparams)
     mempool.AddTransactionsUpdated(1);
     cvBlockChange.notify_all();
 
-    LogPrintf("%s: cut shadow fork active chain from height=%d hash=%s to requested height=%d hash=%s; coins best block moved from %s without replaying historical undo data; removed %u loaded above-cut block index entries\n",
+    LogPrintf("%s: cut shadow fork active chain from height=%d hash=%s to requested height=%d hash=%s by disconnecting %d source blocks; coins best moved from %s; removed %u loaded above-cut block index entries\n",
         __func__, loaded_height, loaded_hash.ToString(), target->nHeight,
-        target->GetBlockHash().ToString(), old_coins_best.ToString(),
+        target->GetBlockHash().ToString(), disconnected, old_coins_best.ToString(),
         static_cast<unsigned int>(removed_above_cut));
     return true;
 }
@@ -5125,7 +5150,8 @@ void static CheckBlockIndex(const Consensus::Params& consensusParams)
         assert((pindexFirstNotTransactionsValid != NULL) == (pindex->nChainTx == 0));
         assert(pindex->nHeight == nHeight); // nHeight must be consistent.
         assert(pindex->pprev == NULL || pindex->nChainWork >= pindex->pprev->nChainWork); // For every block except the genesis block, the chainwork must be larger than the parent's.
-        assert(nHeight < 2 || (pindex->pskip && (pindex->pskip->nHeight < nHeight))); // The pskip pointer must point back for all but the first 2 blocks.
+        assert(nHeight < 2 || (pindex->pskip && (pindex->pskip->nHeight < nHeight)) ||
+               (g_shadowfork_lazy_block_index.enabled && chainActive.Contains(pindex))); // Snapshot-loaded active-chain entries may omit pskip.
         assert(pindexFirstNotTreeValid == NULL); // All mapBlockIndex entries must at least be TREE valid
         if ((pindex->nStatus & BLOCK_VALID_MASK) >= BLOCK_VALID_TREE) assert(pindexFirstNotTreeValid == NULL); // TREE valid implies all parents are TREE valid
         if ((pindex->nStatus & BLOCK_VALID_MASK) >= BLOCK_VALID_CHAIN) assert(pindexFirstNotChainValid == NULL); // CHAIN valid implies all parents are CHAIN valid

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -141,6 +141,21 @@ namespace {
 
     ShadowForkLazyBlockIndexState g_shadowfork_lazy_block_index;
 
+    bool IsShadowForkStartupCutLazyWindow()
+    {
+        return Params().GetConsensus(0).fShadowForkMode &&
+            GetBoolArg("-shadowforkstartupcut", true) &&
+            g_shadowfork_lazy_block_index.enabled &&
+            g_shadowfork_lazy_block_index.active_tip_height == g_shadowfork_lazy_block_index.eager_base_height;
+    }
+
+    bool IsBelowShadowForkStartupCutWindow(int height)
+    {
+        return IsShadowForkStartupCutLazyWindow() &&
+            height >= 0 &&
+            height < g_shadowfork_lazy_block_index.eager_base_height;
+    }
+
     struct CBlockIndexWorkComparator
     {
         bool operator()(CBlockIndex *pa, CBlockIndex *pb) const {
@@ -519,7 +534,17 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp, bool 
                     maxInputHeight = std::max(maxInputHeight, height);
                 }
             }
-            lp->maxInputBlock = tip->GetAncestor(maxInputHeight);
+            if (IsBelowShadowForkStartupCutWindow(maxInputHeight)) {
+                // Shadowfork prepared volumes can contain very old inherited
+                // UTXOs. Caching a lockpoint for those inputs forces lazy
+                // materialization of a deep source-chain ancestor while
+                // holding cs_main, which blocks all RPC workers. Returning a
+                // null lockpoint keeps the mempool check conservative without
+                // hydrating historical block-index ranges.
+                lp->maxInputBlock = NULL;
+            } else {
+                lp->maxInputBlock = tip->GetAncestor(maxInputHeight);
+            }
         }
     }
     return EvaluateSequenceLocks(index, lockPair);
@@ -3765,6 +3790,41 @@ static void TrackLoadedBlockIndexEntry(CBlockIndex* pindex, bool fShadowForkFast
     }
 }
 
+static size_t RemoveLoadedBlockIndexEntriesAboveHeight(int height)
+{
+    std::vector<BlockMap::iterator> entries_to_remove;
+    for (BlockMap::iterator it = mapBlockIndex.begin(); it != mapBlockIndex.end(); ++it) {
+        if (it->second != NULL && it->second->nHeight > height) {
+            entries_to_remove.push_back(it);
+        }
+    }
+
+    for (std::vector<BlockMap::iterator>::iterator it = entries_to_remove.begin(); it != entries_to_remove.end(); ++it) {
+        CBlockIndex* pindex = (*it)->second;
+
+        setBlockIndexCandidates.erase(pindex);
+        setDirtyBlockIndex.erase(pindex);
+        gFailedBlocks.erase(pindex);
+        if (pindexBestInvalid == pindex) {
+            pindexBestInvalid = NULL;
+        }
+
+        for (std::multimap<CBlockIndex*, CBlockIndex*>::iterator linked_it = mapBlocksUnlinked.begin();
+             linked_it != mapBlocksUnlinked.end();) {
+            if (linked_it->first == pindex || linked_it->second == pindex) {
+                mapBlocksUnlinked.erase(linked_it++);
+            } else {
+                ++linked_it;
+            }
+        }
+
+        mapBlockIndex.erase(*it);
+        delete pindex;
+    }
+
+    return entries_to_remove.size();
+}
+
 static void LoadBlockTreeFlags()
 {
     fHavePruned = false;
@@ -4063,8 +4123,31 @@ CBlockIndex* LookupBlockIndex(const uint256& hash)
         return NULL;
     }
 
+    if (Params().GetConsensus(0).fShadowForkMode &&
+        GetBoolArg("-shadowforkstartupcut", true) &&
+        g_shadowfork_lazy_block_index.active_tip_height == g_shadowfork_lazy_block_index.eager_base_height) {
+        ShadowForkActiveChainRecord tip_record;
+        std::string snapshot_error;
+        if (GetShadowForkActiveChainRecordAtHeight(
+                g_shadowfork_lazy_block_index.active_tip_height,
+                &tip_record,
+                &snapshot_error) &&
+            tip_record.block_hash == hash) {
+            if (!TryLoadShadowForkActiveChainSegment(g_shadowfork_lazy_block_index.active_tip_height, true)) {
+                return NULL;
+            }
+            it = mapBlockIndex.find(hash);
+            return it == mapBlockIndex.end() ? NULL : it->second;
+        }
+        return NULL;
+    }
+
     CDiskBlockIndex diskindex;
     if (!pblocktree->ReadBlockIndex(hash, diskindex)) {
+        return NULL;
+    }
+
+    if (diskindex.nHeight > g_shadowfork_lazy_block_index.active_tip_height) {
         return NULL;
     }
 
@@ -4078,6 +4161,16 @@ CBlockIndex* LookupBlockIndex(const uint256& hash)
 
         it = mapBlockIndex.find(hash);
         return it == mapBlockIndex.end() ? NULL : it->second;
+    }
+
+    // In lazy shadowfork mode, do not recursively materialize arbitrary
+    // non-active historical branches. Wallet RPCs call LookupBlockIndex while
+    // holding cs_main to compute transaction depth; hydrating a stale branch
+    // from blocks/index can load millions of ancestors and wedge every RPC
+    // worker behind the same lock. Active-chain hashes are handled above, and
+    // newly mined shadowfork blocks are already present in mapBlockIndex.
+    if (Params().GetConsensus(0).fShadowForkMode) {
+        return NULL;
     }
 
     CBlockIndex* pprev = NULL;
@@ -4112,8 +4205,8 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
     }
 
     const std::string source_chain = GetShadowForkSnapshotSourceChain(chainparams);
-    const uint256 best_block = pcoinsTip->GetBestBlock();
-    if (best_block.IsNull()) {
+    const uint256 chainstate_best_block = pcoinsTip->GetBestBlock();
+    if (chainstate_best_block.IsNull()) {
         LogPrintf("LoadBlockIndexDB(): shadowfork snapshot disabled because chainstate best block is null\n");
         return false;
     }
@@ -4151,14 +4244,38 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
         return false;
     }
 
-    ShadowForkActiveChainRecord snapshot_tip_record;
-    if (!reader.ReadActiveChainRecordAtHeight(metadata.active_tip_height, snapshot_tip_record, &snapshot_error)) {
-        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip read failed: %s; falling back to blocks/index scan\n", snapshot_error);
-        return false;
+    uint256 best_block = chainstate_best_block;
+    int startup_cut_height = -1;
+    ShadowForkActiveChainRecord startup_cut_record;
+    bool have_startup_cut_record = false;
+    if (GetBoolArg("-shadowforkstartupcut", true) && IsArgSet("-shadowfork")) {
+        const int64_t requested_height = GetArg("-shadowfork", -1);
+        if (requested_height >= 0 && requested_height <= metadata.active_tip_height) {
+            if (!reader.ReadActiveChainRecordAtHeight(static_cast<int>(requested_height), startup_cut_record, &snapshot_error)) {
+                LogPrintf("LoadBlockIndexDB(): shadowfork startup-cut snapshot lookup failed at height %d: %s; falling back to blocks/index scan\n",
+                    static_cast<int>(requested_height), snapshot_error);
+                return false;
+            }
+            best_block = startup_cut_record.block_hash;
+            startup_cut_height = static_cast<int>(requested_height);
+            have_startup_cut_record = true;
+            LogPrintf("LoadBlockIndexDB(): shadowfork startup cut height %d is covered by snapshot tip height %d; ignoring chainstate best %s during lazy block-index load\n",
+                startup_cut_height, metadata.active_tip_height, chainstate_best_block.ToString());
+        }
     }
-    if (snapshot_tip_record.block_hash != metadata.active_tip_hash) {
-        LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip hash mismatch; falling back to blocks/index scan\n");
-        return false;
+
+    ShadowForkActiveChainRecord snapshot_tip_record;
+    if (have_startup_cut_record) {
+        snapshot_tip_record = startup_cut_record;
+    } else {
+        if (!reader.ReadActiveChainRecordAtHeight(metadata.active_tip_height, snapshot_tip_record, &snapshot_error)) {
+            LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip read failed: %s; falling back to blocks/index scan\n", snapshot_error);
+            return false;
+        }
+        if (snapshot_tip_record.block_hash != metadata.active_tip_hash) {
+            LogPrintf("LoadBlockIndexDB(): shadowfork snapshot tip hash mismatch; falling back to blocks/index scan\n");
+            return false;
+        }
     }
 
     const int64_t nSnapshotStart = GetTimeMillis();
@@ -4176,7 +4293,7 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
     }
 
     std::vector<CDiskBlockIndex> vDeltaBlocks;
-    if (best_block != metadata.active_tip_hash) {
+    if (startup_cut_height < 0 && best_block != metadata.active_tip_hash) {
         uint256 cursor = best_block;
         while (cursor != metadata.active_tip_hash) {
             CDiskBlockIndex diskindex;
@@ -4205,8 +4322,12 @@ static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)
     g_shadowfork_lazy_block_index.Reset();
     g_shadowfork_lazy_block_index.source_chain = source_chain;
     g_shadowfork_lazy_block_index.snapshot_tip_height = metadata.active_tip_height;
-    g_shadowfork_lazy_block_index.active_tip_height = metadata.active_tip_height + vDeltaBlocks.size();
-    g_shadowfork_lazy_block_index.eager_base_height = std::max(0, g_shadowfork_lazy_block_index.active_tip_height - GetShadowForkSnapshotWindowSize() + 1);
+    g_shadowfork_lazy_block_index.active_tip_height = startup_cut_height >= 0
+        ? startup_cut_height
+        : metadata.active_tip_height + vDeltaBlocks.size();
+    g_shadowfork_lazy_block_index.eager_base_height = startup_cut_height >= 0
+        ? startup_cut_height
+        : std::max(0, g_shadowfork_lazy_block_index.active_tip_height - GetShadowForkSnapshotWindowSize() + 1);
     g_shadowfork_lazy_block_index.fast_candidates = fShadowForkFastCandidates;
     g_shadowfork_lazy_block_index.reader.reset(new ShadowForkSnapshotReader());
     if (!g_shadowfork_lazy_block_index.reader->Open(source_chain, &snapshot_error) ||
@@ -4620,6 +4741,76 @@ bool LoadBlockIndex(const CChainParams& chainparams)
     // Load block index from databases
     if (!fReindex && !LoadBlockIndexDB(chainparams))
         return false;
+    return true;
+}
+
+bool ApplyShadowForkStartupCut(const CChainParams& chainparams)
+{
+    LOCK(cs_main);
+
+    if (!chainparams.GetConsensus(0).fShadowForkMode ||
+        !GetBoolArg("-shadowforkstartupcut", true) ||
+        !IsArgSet("-shadowfork")) {
+        return true;
+    }
+
+    const int64_t requested_height = GetArg("-shadowfork", -1);
+    if (requested_height <= 0) {
+        LogPrintf("%s: no requested positive shadow fork height; keeping loaded source tip height=%d\n",
+            __func__, chainActive.Height());
+        return true;
+    }
+    if (chainActive.Tip() == NULL) {
+        return error("%s: chainActive tip is null", __func__);
+    }
+    if (pcoinsTip == NULL) {
+        return error("%s: coins tip is null", __func__);
+    }
+    if (requested_height > chainActive.Height()) {
+        return error("%s: requested shadow fork height %d is above loaded source height %d",
+            __func__, requested_height, chainActive.Height());
+    }
+
+    CBlockIndex* target = chainActive[static_cast<int>(requested_height)];
+    if (target == NULL) {
+        return error("%s: failed to load active-chain entry at requested shadow fork height %d",
+            __func__, requested_height);
+    }
+
+    const int loaded_height = chainActive.Height();
+    const uint256 loaded_hash = chainActive.Tip()->GetBlockHash();
+    const uint256 old_coins_best = pcoinsTip->GetBestBlock();
+    if (requested_height == loaded_height && old_coins_best == target->GetBlockHash()) {
+        LogPrintf("%s: loaded source tip already matches requested shadow fork height %d (%s)\n",
+            __func__, requested_height, target->GetBlockHash().ToString());
+        return true;
+    }
+
+    chainActive.SetTipWindow(target, target->nHeight);
+    pcoinsTip->SetBestBlock(target->GetBlockHash());
+    pindexBestHeader = target;
+    if (g_shadowfork_lazy_block_index.enabled) {
+        // The prepared-volume snapshot may have been loaded at the source tip.
+        // After a startup cut, on-demand active-chain lookups must treat the
+        // requested fork height as the active ceiling; otherwise wallet locators
+        // or other lazy lookups can rediscover the inherited source tip.
+        g_shadowfork_lazy_block_index.active_tip_height = target->nHeight;
+        g_shadowfork_lazy_block_index.eager_base_height = target->nHeight;
+    }
+    const size_t removed_above_cut = RemoveLoadedBlockIndexEntriesAboveHeight(target->nHeight);
+
+    // Keep future source-chain blocks out of ActivateBestChain after the cut.
+    // Shadowfork instances mine from the requested height; they should not
+    // select the inherited source tip again just because it has more work.
+    setBlockIndexCandidates.clear();
+    setBlockIndexCandidates.insert(target);
+    mempool.AddTransactionsUpdated(1);
+    cvBlockChange.notify_all();
+
+    LogPrintf("%s: cut shadow fork active chain from height=%d hash=%s to requested height=%d hash=%s; coins best block moved from %s without replaying historical undo data; removed %u loaded above-cut block index entries\n",
+        __func__, loaded_height, loaded_hash.ToString(), target->nHeight,
+        target->GetBlockHash().ToString(), old_coins_best.ToString(),
+        static_cast<unsigned int>(removed_above_cut));
     return true;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -107,6 +107,11 @@ namespace {
         return params.GetConsensus(0).fShadowForkMode && GetBoolArg(arg, true);
     }
 
+    bool IsShadowForkInstantMiningEnabled(const Consensus::Params& consensusParams)
+    {
+        return consensusParams.fShadowForkMode && GetBoolArg("-shadowforkinstantmining", true);
+    }
+
     struct ShadowForkLazyBlockIndexState
     {
         bool enabled;
@@ -1272,8 +1277,7 @@ static bool ReadBlockOrHeader(T& block, const CDiskBlockPos& pos, const Consensu
     }
 
     // Shadowfork instant-mined blocks do not satisfy canonical PoW checks.
-    const bool fSkipShadowForkPow =
-        consensusParams.fShadowForkMode && GetBoolArg("-shadowforkinstantmining", true);
+    const bool fSkipShadowForkPow = IsShadowForkInstantMiningEnabled(consensusParams);
 
     // Check the header
     if (fCheckPOW && !fSkipShadowForkPow && !CheckAuxPowProofOfWork(block, consensusParams))
@@ -1904,7 +1908,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // is enforced in ContextualCheckBlockHeader(); we wouldn't want to
     // re-enforce that rule here (at least until we make it impossible for
     // GetAdjustedTime() to go backward).
-    if (!CheckBlock(block, state, !fJustCheck, !fJustCheck)) {
+    const bool fCheckPOW = !fJustCheck && !IsShadowForkInstantMiningEnabled(consensus);
+    if (!CheckBlock(block, state, fCheckPOW, !fJustCheck)) {
         if (state.CorruptionPossible()) {
             LogPrintf("%s: Attempt to connect corrupted block %s.\n", __func__, block.GetHash().ToString());
             // We don't write down blocks to disk if they may have been
@@ -3061,8 +3066,7 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, bool f
     // knowing the previous block), but that's okay, as the checks done are permissive
     // (i.e. doesn't check work limit or whether AuxPoW is enabled)
     const Consensus::Params& consensus = Params().GetConsensus(0);
-    const bool fSkipShadowForkPow = consensus.fShadowForkMode && GetBoolArg("-shadowforkinstantmining", true);
-    if (fCheckPOW && !fSkipShadowForkPow && !CheckAuxPowProofOfWork(block, consensus))
+    if (fCheckPOW && !CheckAuxPowProofOfWork(block, consensus))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
     return true;
@@ -3340,7 +3344,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const CB
     return true;
 }
 
-static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex)
+static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fCheckPOW = true)
 {
     AssertLockHeld(cs_main);
     // Check for duplicate
@@ -3359,7 +3363,7 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
             return true;
         }
 
-        if (!CheckBlockHeader(block, state))
+        if (!CheckBlockHeader(block, state, fCheckPOW))
             return error("%s: Consensus::CheckBlockHeader: %s, %s", __func__, hash.ToString(), FormatStateMessage(state));
 
         // Get prev block index
@@ -3424,7 +3428,7 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
 }
 
 /** Store block on disk. If dbp is non-NULL, the file is known to already reside on disk */
-static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock)
+static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock, bool fCheckPOW = true)
 {
     const CBlock& block = *pblock;
 
@@ -3434,7 +3438,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     CBlockIndex *pindexDummy = NULL;
     CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
 
-    if (!AcceptBlockHeader(block, state, chainparams, &pindex))
+    if (!AcceptBlockHeader(block, state, chainparams, &pindex, fCheckPOW))
         return false;
 
     // Try to process all requested blocks that we don't have, but only
@@ -3464,7 +3468,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
     if (fNewBlock) *fNewBlock = true;
 
-    if (!CheckBlock(block, state) ||
+    if (!CheckBlock(block, state, fCheckPOW) ||
         !ContextualCheckBlock(block, state, pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
@@ -3503,7 +3507,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     return true;
 }
 
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock)
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock, bool fCheckPOW)
 {
     {
         CBlockIndex *pindex = NULL;
@@ -3511,13 +3515,13 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         CValidationState state;
         // Ensure that CheckBlock() passes before calling AcceptBlock, as
         // belt-and-suspenders.
-        bool ret = CheckBlock(*pblock, state);
+        bool ret = CheckBlock(*pblock, state, fCheckPOW);
 
         LOCK(cs_main);
 
         if (ret) {
             // Store to disk
-            ret = AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, NULL, fNewBlock);
+            ret = AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, NULL, fNewBlock, fCheckPOW);
         }
         CheckBlockIndex(chainparams.GetConsensus(chainActive.Height()));
         if (!ret) {
@@ -4575,7 +4579,8 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         if (!ReadBlockFromDisk(block, pindex, chainparams.GetConsensus(pindex->nHeight)))
             return error("VerifyDB(): *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
         // check level 1: verify block validity
-        if (nCheckLevel >= 1 && !CheckBlock(block, state))
+        const bool fVerifyPOW = !IsShadowForkInstantMiningEnabled(chainparams.GetConsensus(pindex->nHeight));
+        if (nCheckLevel >= 1 && !CheckBlock(block, state, fVerifyPOW))
             return error("%s: *** found bad block at %d, hash=%s (%s)\n", __func__,
                          pindex->nHeight, pindex->GetBlockHash().ToString(), FormatStateMessage(state));
         // check level 2: verify undo validity
@@ -5017,7 +5022,8 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                 if (mapBlockIndex.count(hash) == 0 || (mapBlockIndex[hash]->nStatus & BLOCK_HAVE_DATA) == 0) {
                     LOCK(cs_main);
                     CValidationState state;
-                    if (AcceptBlock(pblock, state, chainparams, NULL, true, dbp, NULL))
+                    const bool fCheckPOW = !IsShadowForkInstantMiningEnabled(chainparams.GetConsensus(0));
+                    if (AcceptBlock(pblock, state, chainparams, NULL, true, dbp, NULL, fCheckPOW))
                         nLoaded++;
                     if (state.IsError())
                         break;
@@ -5052,7 +5058,8 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                                     head.ToString());
                             LOCK(cs_main);
                             CValidationState dummy;
-                            if (AcceptBlock(pblockrecursive, dummy, chainparams, NULL, true, &it->second, NULL))
+                            const bool fCheckPOW = !IsShadowForkInstantMiningEnabled(chainparams.GetConsensus(0));
+                            if (AcceptBlock(pblockrecursive, dummy, chainparams, NULL, true, &it->second, NULL, fCheckPOW))
                             {
                                 nLoaded++;
                                 queue.push_back(pblockrecursive->GetHash());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3818,6 +3818,17 @@ static int GetShadowForkSnapshotWindowSize()
     return std::max(1, configured);
 }
 
+static int GetShadowForkActiveChainSegmentStart(int height)
+{
+    int start = std::max(0, height - SHADOWFORK_LAZY_ACTIVE_CHAIN_CHUNK + 1);
+    if (height >= g_shadowfork_lazy_block_index.eager_base_height) {
+        start = std::max(start, g_shadowfork_lazy_block_index.eager_base_height);
+    }
+    return start;
+}
+
+static bool TryLoadShadowForkActiveChainSegment(int height, bool fShadowForkFastCandidates);
+
 static bool GetShadowForkActiveChainRecordAtHeight(int height, ShadowForkActiveChainRecord* record, std::string* error)
 {
     if (!g_shadowfork_lazy_block_index.enabled) {
@@ -3920,6 +3931,36 @@ static bool PopulateShadowForkDiskIndexEntry(const CDiskBlockIndex& diskindex, C
     return true;
 }
 
+static bool EnsureShadowForkActiveChainParentLoaded(CBlockIndex* pindex, bool fShadowForkFastCandidates)
+{
+    if (!g_shadowfork_lazy_block_index.enabled || pindex == NULL || pindex->nHeight <= 0 || pindex->pprev != NULL) {
+        return true;
+    }
+
+    if (!TryLoadShadowForkActiveChainSegment(pindex->nHeight - 1, fShadowForkFastCandidates)) {
+        return false;
+    }
+
+    std::string snapshot_error;
+    ShadowForkActiveChainRecord prev_record;
+    if (!GetShadowForkActiveChainRecordAtHeight(pindex->nHeight - 1, &prev_record, &snapshot_error)) {
+        LogPrintf("EnsureShadowForkActiveChainParentLoaded(): failed to read snapshot height %d: %s\n",
+            pindex->nHeight - 1, snapshot_error);
+        return false;
+    }
+
+    BlockMap::iterator prev_it = mapBlockIndex.find(prev_record.block_hash);
+    if (prev_it == mapBlockIndex.end()) {
+        LogPrintf("EnsureShadowForkActiveChainParentLoaded(): previous active-chain block %s missing at height %d\n",
+            prev_record.block_hash.ToString(), pindex->nHeight - 1);
+        return false;
+    }
+
+    pindex->pprev = prev_it->second;
+    pindex->BuildSkip();
+    return true;
+}
+
 static bool TryLoadShadowForkActiveChainSegment(int height, bool fShadowForkFastCandidates)
 {
     AssertLockHeld(cs_main);
@@ -3937,12 +3978,15 @@ static bool TryLoadShadowForkActiveChainSegment(int height, bool fShadowForkFast
 
     BlockMap::iterator existing_tip = mapBlockIndex.find(height_record.block_hash);
     if (existing_tip != mapBlockIndex.end()) {
+        if (!EnsureShadowForkActiveChainParentLoaded(existing_tip->second, fShadowForkFastCandidates)) {
+            return false;
+        }
         return true;
     }
 
-    int start = height;
+    const int start = GetShadowForkActiveChainSegmentStart(height);
     CBlockIndex* pprev = NULL;
-    while (start > 0) {
+    if (start > 0) {
         ShadowForkActiveChainRecord prev_record;
         if (!GetShadowForkActiveChainRecordAtHeight(start - 1, &prev_record, &snapshot_error)) {
             LogPrintf("TryLoadShadowForkActiveChainSegment(): failed to read snapshot height %d: %s\n", start - 1, snapshot_error);
@@ -3952,10 +3996,7 @@ static bool TryLoadShadowForkActiveChainSegment(int height, bool fShadowForkFast
         BlockMap::iterator prev_it = mapBlockIndex.find(prev_record.block_hash);
         if (prev_it != mapBlockIndex.end()) {
             pprev = prev_it->second;
-            break;
         }
-
-        --start;
     }
 
     for (int cursor = start; cursor <= height; ++cursor) {
@@ -3967,6 +4008,9 @@ static bool TryLoadShadowForkActiveChainSegment(int height, bool fShadowForkFast
 
         BlockMap::iterator it = mapBlockIndex.find(record.block_hash);
         if (it != mapBlockIndex.end()) {
+            if (!EnsureShadowForkActiveChainParentLoaded(it->second, fShadowForkFastCandidates)) {
+                return false;
+            }
             pprev = it->second;
             continue;
         }
@@ -3998,7 +4042,13 @@ CBlockIndex* LoadShadowForkActiveChainIndex(int nHeight)
         return NULL;
     }
     BlockMap::iterator it = mapBlockIndex.find(record.block_hash);
-    return it == mapBlockIndex.end() ? NULL : it->second;
+    if (it == mapBlockIndex.end()) {
+        return NULL;
+    }
+    if (!EnsureShadowForkActiveChainParentLoaded(it->second, true)) {
+        return NULL;
+    }
+    return it->second;
 }
 
 CBlockIndex* LookupBlockIndex(const uint256& hash)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3883,6 +3883,43 @@ static bool PopulateShadowForkActiveChainEntry(int height, const ShadowForkActiv
     return true;
 }
 
+static bool PopulateShadowForkDiskIndexEntry(const CDiskBlockIndex& diskindex, CBlockIndex* pprev, bool fShadowForkFastCandidates, CBlockIndex** ppindex)
+{
+    const uint256 block_hash = diskindex.GetBlockHash();
+    if (block_hash.IsNull()) {
+        LogPrintf("PopulateShadowForkDiskIndexEntry(): null block hash at height %d\n", diskindex.nHeight);
+        return false;
+    }
+    if ((diskindex.nHeight == 0 && !diskindex.hashPrev.IsNull()) ||
+        (diskindex.nHeight > 0 &&
+         (pprev == NULL || diskindex.hashPrev != pprev->GetBlockHash()))) {
+        LogPrintf("PopulateShadowForkDiskIndexEntry(): parent mismatch for %s at height %d\n",
+            block_hash.ToString(), diskindex.nHeight);
+        return false;
+    }
+
+    CBlockIndex* pindex = InsertBlockIndex(block_hash);
+    pindex->pprev = pprev;
+    pindex->nHeight = diskindex.nHeight;
+    pindex->nFile = diskindex.nFile;
+    pindex->nDataPos = diskindex.nDataPos;
+    pindex->nUndoPos = diskindex.nUndoPos;
+    pindex->nVersion = diskindex.nVersion;
+    pindex->hashMerkleRoot = diskindex.hashMerkleRoot;
+    pindex->nTime = diskindex.nTime;
+    pindex->nBits = diskindex.nBits;
+    pindex->nNonce = diskindex.nNonce;
+    pindex->nStatus = diskindex.nStatus;
+    pindex->nTx = diskindex.nTx;
+    pindex->nChainWork = diskindex.nChainWork;
+    pindex->nChainTx = diskindex.nChainTx;
+    pindex->nTimeMax = diskindex.nTimeMax;
+
+    TrackLoadedBlockIndexEntry(pindex, fShadowForkFastCandidates, false);
+    *ppindex = pindex;
+    return true;
+}
+
 static bool TryLoadShadowForkActiveChainSegment(int height, bool fShadowForkFastCandidates)
 {
     AssertLockHeld(cs_main);
@@ -3983,18 +4020,29 @@ CBlockIndex* LookupBlockIndex(const uint256& hash)
 
     ShadowForkActiveChainRecord record;
     std::string snapshot_error;
-    if (!GetShadowForkActiveChainRecordAtHeight(diskindex.nHeight, &record, &snapshot_error)) {
-        return NULL;
-    }
-    if (record.block_hash != hash) {
-        return NULL;
-    }
-    if (!TryLoadShadowForkActiveChainSegment(diskindex.nHeight, true)) {
-        return NULL;
+    if (GetShadowForkActiveChainRecordAtHeight(diskindex.nHeight, &record, &snapshot_error) &&
+        record.block_hash == hash) {
+        if (!TryLoadShadowForkActiveChainSegment(diskindex.nHeight, true)) {
+            return NULL;
+        }
+
+        it = mapBlockIndex.find(hash);
+        return it == mapBlockIndex.end() ? NULL : it->second;
     }
 
-    it = mapBlockIndex.find(hash);
-    return it == mapBlockIndex.end() ? NULL : it->second;
+    CBlockIndex* pprev = NULL;
+    if (!diskindex.hashPrev.IsNull()) {
+        pprev = LookupBlockIndex(diskindex.hashPrev);
+        if (pprev == NULL) {
+            return NULL;
+        }
+    }
+
+    CBlockIndex* pindex = NULL;
+    if (!PopulateShadowForkDiskIndexEntry(diskindex, pprev, false, &pindex)) {
+        return NULL;
+    }
+    return pindex;
 }
 
 static bool TryLoadShadowForkSnapshot(const CChainParams& chainparams)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3918,9 +3918,6 @@ static bool TryLoadShadowForkActiveChainSegment(int height, bool fShadowForkFast
             break;
         }
 
-        if (height - start + 1 >= SHADOWFORK_LAZY_ACTIVE_CHAIN_CHUNK) {
-            break;
-        }
         --start;
     }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -329,6 +329,8 @@ void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
 /** Create a new block index entry for a given block hash */
 CBlockIndex * InsertBlockIndex(uint256 hash);
+/** Return a block index entry only if it is already materialized in memory. */
+CBlockIndex* FindLoadedBlockIndex(const uint256& hash);
 /** Return a loaded block index entry, lazily materializing active-chain entries in shadowfork mode when needed. */
 CBlockIndex* LookupBlockIndex(const uint256& hash);
 /** Flush all state, indexes and buffers to disk. */

--- a/src/validation.h
+++ b/src/validation.h
@@ -271,6 +271,8 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
 bool InitBlockIndex(const CChainParams& chainparams);
 /** Load the block tree and coins database from disk */
 bool LoadBlockIndex(const CChainParams& chainparams);
+/** Build or refresh the global shadowfork block-index snapshot from the current source datadir. */
+bool BuildShadowForkBlockIndexSnapshot(const CChainParams& chainparams);
 /** Unload database information */
 void UnloadBlockIndex();
 /** Run an instance of the script checking thread */
@@ -325,6 +327,8 @@ void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
 /** Create a new block index entry for a given block hash */
 CBlockIndex * InsertBlockIndex(uint256 hash);
+/** Return a loaded block index entry, lazily materializing active-chain entries in shadowfork mode when needed. */
+CBlockIndex* LookupBlockIndex(const uint256& hash);
 /** Flush all state, indexes and buffers to disk. */
 void FlushStateToDisk();
 /** Prune block files and flush state to disk. */

--- a/src/validation.h
+++ b/src/validation.h
@@ -233,17 +233,18 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 2200ULL * 1024 * 1024;
  * install a CValidationInterface (see validationinterface.h) - this will have
  * its BlockChecked method called whenever *any* block completes validation.
  *
- * Note that we guarantee that either the proof-of-work is valid on pblock, or
- * (and possibly also) BlockChecked will have been called.
+ * Note that when fCheckPOW is true we guarantee that either the proof-of-work
+ * is valid on pblock, or (and possibly also) BlockChecked will have been called.
  * 
  * Call without cs_main held.
  *
  * @param[in]   pblock  The block we want to process.
  * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
  * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
+ * @param[in]   fCheckPOW Whether to verify proof-of-work while accepting this block.
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock);
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock, bool fCheckPOW = true);
 
 /**
  * Process incoming block headers.

--- a/src/validation.h
+++ b/src/validation.h
@@ -273,6 +273,8 @@ bool InitBlockIndex(const CChainParams& chainparams);
 bool LoadBlockIndex(const CChainParams& chainparams);
 /** Build or refresh the global shadowfork block-index snapshot from the current source datadir. */
 bool BuildShadowForkBlockIndexSnapshot(const CChainParams& chainparams);
+/** In shadowfork mode, cut the active chain to -shadowfork=<height> after startup verification. */
+bool ApplyShadowForkStartupCut(const CChainParams& chainparams);
 /** Unload database information */
 void UnloadBlockIndex();
 /** Run an instance of the script checking thread */

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -18,8 +18,40 @@ const struct BIP9DeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION
     {
         /*.name =*/ "segwit",
         /*.gbt_force =*/ true,
-    }
+	}
 };
+
+namespace {
+
+bool GetShadowForkVersionBitsOverride(const Consensus::Params& params, Consensus::DeploymentPos pos, ThresholdState* state, int* since_height = nullptr)
+{
+    if (!params.fShadowForkMode) {
+        return false;
+    }
+
+    switch (pos) {
+    case Consensus::DEPLOYMENT_CSV:
+        *state = THRESHOLD_ACTIVE;
+        break;
+    case Consensus::DEPLOYMENT_SEGWIT:
+        *state = (params.vDeployments[pos].nTimeout == 0) ? THRESHOLD_FAILED : THRESHOLD_ACTIVE;
+        break;
+    default:
+        *state = THRESHOLD_DEFINED;
+        break;
+    }
+
+    if (since_height != nullptr) {
+        // Shadow forks flatten inherited consensus into a synthetic chain that is
+        // intended to behave like the already-activated source tip. Report the
+        // override as applying from the start of the forked chain.
+        *since_height = 0;
+    }
+
+    return true;
+}
+
+} // namespace
 
 ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex* pindexPrev, const Consensus::Params& params, ThresholdConditionCache& cache) const
 {
@@ -164,11 +196,20 @@ public:
 
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache)
 {
+    ThresholdState override_state;
+    if (GetShadowForkVersionBitsOverride(params, pos, &override_state)) {
+        return override_state;
+    }
     return VersionBitsConditionChecker(pos).GetStateFor(pindexPrev, params, cache.caches[pos]);
 }
 
 int VersionBitsStateSinceHeight(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache)
 {
+    ThresholdState override_state;
+    int override_since_height = 0;
+    if (GetShadowForkVersionBitsOverride(params, pos, &override_state, &override_since_height)) {
+        return override_since_height;
+    }
     return VersionBitsConditionChecker(pos).GetStateSinceHeightFor(pindexPrev, params, cache.caches[pos]);
 }
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -184,8 +184,16 @@ void attemptRescanFromHeight(const uint32_t nHeight)
     else
         pblockindex = chainActive[nHeight];
 
+    if (Params().GetConsensus(chainActive.Height()).fShadowForkMode && chainActive.WindowStartHeight() > 0) {
+        if (pblockindex == NULL || pblockindex->nHeight < chainActive.WindowStartHeight())
+            pblockindex = chainActive[chainActive.WindowStartHeight()];
+    }
+    if (pblockindex == NULL)
+        throw JSONRPCError(RPC_MISC_ERROR, "Rescan start block is not available");
+
     pwalletMain->ScanForWalletTransactions(pblockindex, true);
-    pwalletMain->ReacceptWalletTransactions();
+    if (!Params().GetConsensus(chainActive.Height()).fShadowForkMode)
+        pwalletMain->ReacceptWalletTransactions();
 }
 
 void ImportAddress(const CBitcoinAddress& address, const string& strLabel);
@@ -538,6 +546,12 @@ UniValue importwallet(const JSONRPCRequest& request)
     pwalletMain->UpdateTimeFirstKey(nTimeBegin);
 
     CBlockIndex *pindex = chainActive.FindEarliestAtLeast(nTimeBegin - 7200);
+    if (Params().GetConsensus(chainActive.Height()).fShadowForkMode && chainActive.WindowStartHeight() > 0) {
+        if (pindex == NULL || pindex->nHeight < chainActive.WindowStartHeight())
+            pindex = chainActive[chainActive.WindowStartHeight()];
+    }
+    if (pindex == NULL)
+        throw JSONRPCError(RPC_MISC_ERROR, "Rescan start block is not available");
 
     LogPrintf("Rescanning last %i blocks\n", pindex ? chainActive.Height() - pindex->nHeight + 1 : 0);
     pwalletMain->ScanForWalletTransactions(pindex);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -322,7 +322,8 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
 
         LOCK(cs_main);
 
-        if (!mapBlockIndex.count(merkleBlock.header.GetHash()) || !chainActive.Contains(mapBlockIndex[merkleBlock.header.GetHash()]))
+        CBlockIndex* pindex = LookupBlockIndex(merkleBlock.header.GetHash());
+        if (pindex == NULL || !chainActive.Contains(pindex))
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found in chain");
 
         vector<uint256>::const_iterator it;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -69,7 +69,10 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     {
         entry.pushKV("blockhash", wtx.hashBlock.GetHex());
         entry.pushKV("blockindex", wtx.nIndex);
-        entry.pushKV("blocktime", mapBlockIndex[wtx.hashBlock]->GetBlockTime());
+        CBlockIndex* pindex = LookupBlockIndex(wtx.hashBlock);
+        if (pindex) {
+            entry.pushKV("blocktime", pindex->GetBlockTime());
+        }
     } else {
         entry.pushKV("trusted", wtx.IsTrusted());
     }
@@ -1895,10 +1898,9 @@ UniValue listsinceblock(const JSONRPCRequest& request)
         uint256 blockId;
 
         blockId.SetHex(request.params[0].get_str());
-        BlockMap::iterator it = mapBlockIndex.find(blockId);
-        if (it != mapBlockIndex.end())
+        pindex = LookupBlockIndex(blockId);
+        if (pindex != NULL)
         {
-            pindex = it->second;
             if (chainActive[pindex->nHeight] != pindex)
             {
                 // the block being asked for is a part of a deactivated chain;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -911,7 +911,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
         wtx.nTimeSmart = wtx.nTimeReceived;
         if (!wtxIn.hashUnset())
         {
-            if (mapBlockIndex.count(wtxIn.hashBlock))
+            if (LookupBlockIndex(wtxIn.hashBlock))
             {
                 int64_t latestNow = wtx.nTimeReceived;
                 int64_t latestEntry = 0;
@@ -944,8 +944,11 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
                     }
                 }
 
-                int64_t blocktime = mapBlockIndex[wtxIn.hashBlock]->GetBlockTime();
-                wtx.nTimeSmart = std::max(latestEntry, std::min(blocktime, latestNow));
+                CBlockIndex* pindex = LookupBlockIndex(wtxIn.hashBlock);
+                if (pindex) {
+                    int64_t blocktime = pindex->GetBlockTime();
+                    wtx.nTimeSmart = std::max(latestEntry, std::min(blocktime, latestNow));
+                }
             }
             else
                 LogPrintf("AddToWallet(): found %s in block %s not in index\n",
@@ -1001,7 +1004,8 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
 
     if ( !strCmd.empty())
     {
-        int64_t nHeight = wtxIn.hashUnset() ? 0 : mapBlockIndex[wtxIn.hashBlock]->nHeight;
+        CBlockIndex* pindex = wtxIn.hashUnset() ? NULL : LookupBlockIndex(wtxIn.hashBlock);
+        int64_t nHeight = pindex ? pindex->nHeight : 0;
         boost::replace_all(strCmd, "%s", wtxIn.GetHash().GetHex());
         boost::replace_all(strCmd, "%i", boost::lexical_cast<std::string>(nHeight));
         boost::thread t(runCommand, strCmd); // thread runs free
@@ -1140,11 +1144,9 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
     LOCK2(cs_main, cs_wallet);
 
     int conflictconfirms = 0;
-    if (mapBlockIndex.count(hashBlock)) {
-        CBlockIndex* pindex = mapBlockIndex[hashBlock];
-        if (chainActive.Contains(pindex)) {
-            conflictconfirms = -(chainActive.Height() - pindex->nHeight + 1);
-        }
+    CBlockIndex* pindex = LookupBlockIndex(hashBlock);
+    if (pindex && chainActive.Contains(pindex)) {
+        conflictconfirms = -(chainActive.Height() - pindex->nHeight + 1);
     }
     // If number of conflict confirms cannot be determined, this means
     // that the block is still unknown or not yet part of the main chain,
@@ -3577,10 +3579,10 @@ void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) c
     for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); it++) {
         // iterate over all wallet transactions...
         const CWalletTx &wtx = (*it).second;
-        BlockMap::const_iterator blit = mapBlockIndex.find(wtx.hashBlock);
-        if (blit != mapBlockIndex.end() && chainActive.Contains(blit->second)) {
+        CBlockIndex* pindex = LookupBlockIndex(wtx.hashBlock);
+        if (pindex && chainActive.Contains(pindex)) {
             // ... which are already in a block
-            int nHeight = blit->second->nHeight;
+            int nHeight = pindex->nHeight;
             BOOST_FOREACH(const CTxOut &txout, wtx.tx->vout) {
                 // iterate over all their outputs
                 CAffectedKeysVisitor(*this, vAffected).Process(txout.scriptPubKey);
@@ -3588,7 +3590,7 @@ void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) c
                     // ... and all their affected keys
                     std::map<CKeyID, CBlockIndex*>::iterator rit = mapKeyFirstBlock.find(keyid);
                     if (rit != mapKeyFirstBlock.end() && nHeight < rit->second->nHeight)
-                        rit->second = blit->second;
+                        rit->second = pindex;
                 }
                 vAffected.clear();
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3847,7 +3847,12 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
     RegisterValidationInterface(walletInstance);
 
     CBlockIndex *pindexRescan = chainActive.Tip();
-    if (GetBoolArg("-rescan", false))
+    const bool fShadowForkMode = Params().GetConsensus(chainActive.Height()).fShadowForkMode;
+    if (fShadowForkMode) {
+        // Shadowfork datadirs are cloned from an already-synced frozen base, so
+        // the wallet's persisted locator should not drive a rescan decision here.
+        LogPrintf("Shadowfork wallet init: using active tip directly and skipping locator-based rescan selection\n");
+    } else if (GetBoolArg("-rescan", false))
         pindexRescan = chainActive.Genesis();
     else
     {
@@ -3957,7 +3962,12 @@ void CWallet::postInitProcess(boost::thread_group& threadGroup)
 {
     // Add wallet transactions that aren't already in a block to mempool
     // Do this here as mempool requires genesis block to be loaded
-    ReacceptWalletTransactions();
+    const bool fShadowForkMode = Params().GetConsensus(chainActive.Height()).fShadowForkMode;
+    if (fShadowForkMode) {
+        LogPrintf("Shadowfork wallet post-init: skipping ReacceptWalletTransactions on cloned base\n");
+    } else {
+        ReacceptWalletTransactions();
+    }
 
     // Run a thread to flush wallet periodically
     if (!CWallet::fFlushThreadRunning.exchange(true)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -31,6 +31,7 @@
 #include "utilmoneystr.h"
 
 #include <assert.h>
+#include <memory>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/lexical_cast.hpp>
@@ -49,6 +50,12 @@ bool fWalletRbf = DEFAULT_WALLET_RBF;
 const char * DEFAULT_WALLET_DAT = "wallet.dat";
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 const uint32_t BIP44_COIN_TYPE = 3;
+
+static bool IsShadowForkMemoryOnlyWallet()
+{
+    return Params().GetConsensus(0).fShadowForkMode &&
+        GetBoolArg("-shadowforkskipwalletrescan", true);
+}
 
 /**
  * Fees smaller than this (in satoshi) are considered zero fee (for transaction creation)
@@ -272,6 +279,11 @@ bool CWallet::AddWatchOnly(const CScript& dest)
     const CKeyMetadata& meta = mapKeyMetadata[CScriptID(dest)];
     UpdateTimeFirstKey(meta.nCreateTime);
     NotifyWatchonlyChanged(true);
+    if (IsShadowForkMemoryOnlyWallet()) {
+        LogPrintf("%s: shadow fork mode: added watch-only script in memory without wallet DB write\n",
+            __func__);
+        return true;
+    }
     if (!fFileBacked)
         return true;
     return CWalletDB(strWalletFile).WriteWatchOnly(dest, meta);
@@ -771,6 +783,8 @@ int64_t CWallet::IncOrderPosNext(CWalletDB *pwalletdb)
 {
     AssertLockHeld(cs_wallet); // nOrderPosNext
     int64_t nRet = nOrderPosNext++;
+    if (IsShadowForkMemoryOnlyWallet())
+        return nRet;
     if (pwalletdb) {
         pwalletdb->WriteOrderPosNext(nOrderPosNext);
     } else {
@@ -893,7 +907,10 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
 {
     LOCK(cs_wallet);
 
-    CWalletDB walletdb(strWalletFile, "r+", fFlushOnClose);
+    const bool fMemoryOnly = IsShadowForkMemoryOnlyWallet();
+    std::unique_ptr<CWalletDB> walletdb;
+    if (!fMemoryOnly)
+        walletdb.reset(new CWalletDB(strWalletFile, "r+", fFlushOnClose));
 
     uint256 hash = wtxIn.GetHash();
 
@@ -905,7 +922,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     if (fInsertedNew)
     {
         wtx.nTimeReceived = GetAdjustedTime();
-        wtx.nOrderPos = IncOrderPosNext(&walletdb);
+        wtx.nOrderPos = IncOrderPosNext(walletdb.get());
         wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry*)0)));
 
         wtx.nTimeSmart = wtx.nTimeReceived;
@@ -989,9 +1006,14 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     LogPrintf("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""), (fUpdated ? "update" : ""));
 
     // Write to disk
-    if (fInsertedNew || fUpdated)
-        if (!walletdb.WriteTx(wtx))
+    if (fInsertedNew || fUpdated) {
+        if (fMemoryOnly) {
+            LogPrintf("%s: shadow fork mode: retained wallet tx in memory without wallet DB write\n",
+                __func__);
+        } else if (!walletdb->WriteTx(wtx)) {
             return false;
+        }
+    }
 
     // Break debit/credit balance caches:
     wtx.MarkDirty();
@@ -1016,6 +1038,16 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
 
 bool CWallet::LoadToWallet(const CWalletTx& wtxIn)
 {
+    if (IsShadowForkMemoryOnlyWallet()) {
+        static unsigned int nSkippedHistoricalShadowForkWalletTx = 0;
+        if (nSkippedHistoricalShadowForkWalletTx == 0) {
+            LogPrintf("%s: shadow fork mode: skipping historical wallet transactions from wallet DB\n",
+                __func__);
+        }
+        ++nSkippedHistoricalShadowForkWalletTx;
+        return true;
+    }
+
     uint256 hash = wtxIn.GetHash();
 
     mapWallet[hash] = wtxIn;
@@ -1535,6 +1567,14 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool f
     CBlockIndex* pindex = pindexStart;
     {
         LOCK2(cs_main, cs_wallet);
+
+        if (IsShadowForkMemoryOnlyWallet()) {
+            LogPrintf("%s: shadow fork mode: skipped wallet rescan from height=%d tip=%d\n",
+                __func__,
+                pindex ? pindex->nHeight : -1,
+                chainActive.Tip() ? chainActive.Tip()->nHeight : -1);
+            return chainActive.Tip();
+        }
 
         // no need to read and scan block, if block was created before
         // our wallet birthday (as adjusted for block time variability)
@@ -3038,6 +3078,11 @@ bool CWallet::SetAddressBook(const CTxDestination& address, const string& strNam
     }
     NotifyAddressBookChanged(this, address, strName, ::IsMine(*this, address) != ISMINE_NO,
                              strPurpose, (fUpdated ? CT_UPDATED : CT_NEW) );
+    if (IsShadowForkMemoryOnlyWallet()) {
+        LogPrintf("%s: shadow fork mode: updated address book in memory without wallet DB write for %s\n",
+            __func__, CBitcoinAddress(address).ToString());
+        return true;
+    }
     if (!fFileBacked)
         return false;
     if (!strPurpose.empty() && !CWalletDB(strWalletFile).WritePurpose(CBitcoinAddress(address).ToString(), strPurpose))
@@ -3685,6 +3730,15 @@ std::string CWallet::GetWalletHelpString(bool showDebug)
     return strUsage;
 }
 
+static CBlockLocator GetWalletBestChainLocator()
+{
+    if (IsShadowForkMemoryOnlyWallet() && chainActive.Tip() != NULL) {
+        return CBlockLocator(std::vector<uint256>(1, chainActive.Tip()->GetBlockHash()));
+    }
+
+    return chainActive.GetLocator();
+}
+
 CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
 {
     // needed to restore wallet transaction meta data after -zapwallettxes
@@ -3774,7 +3828,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
             }
         }
 
-        walletInstance->SetBestChain(chainActive.GetLocator());
+        walletInstance->SetBestChain(GetWalletBestChainLocator());
     }
     else if (IsArgSet("-usehd")) {
         bool useHD = GetBoolArg("-usehd", DEFAULT_USE_HD_WALLET);
@@ -3799,10 +3853,18 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
     {
         CWalletDB walletdb(walletFile);
         CBlockLocator locator;
-        if (walletdb.ReadBestBlock(locator))
+        if (walletdb.ReadBestBlock(locator)) {
             pindexRescan = FindForkInGlobalIndex(chainActive, locator);
-        else
+            if (IsShadowForkMemoryOnlyWallet() && pindexRescan != chainActive.Tip()) {
+                LogPrintf("Shadow fork wallet rescan skipped: wallet best fork height=%d, active tip height=%d\n",
+                    pindexRescan ? pindexRescan->nHeight : -1,
+                    chainActive.Tip() ? chainActive.Tip()->nHeight : -1);
+                pindexRescan = chainActive.Tip();
+                walletInstance->SetBestChain(GetWalletBestChainLocator());
+            }
+        } else {
             pindexRescan = chainActive.Genesis();
+        }
     }
     if (chainActive.Tip() && chainActive.Tip() != pindexRescan)
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3812,8 +3812,12 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
         if (fPruneMode)
         {
             CBlockIndex *block = chainActive.Tip();
-            while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA) && block->pprev->nTx > 0 && pindexRescan != block)
-                block = block->pprev;
+            while (block && block->nHeight > 0 && pindexRescan != block) {
+                CBlockIndex* prev = chainActive[block->nHeight - 1];
+                if (prev == NULL || !(prev->nStatus & BLOCK_HAVE_DATA) || prev->nTx <= 0)
+                    break;
+                block = prev;
+            }
 
             if (pindexRescan != block) {
                 InitError(_("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)"));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -51,10 +51,16 @@ const char * DEFAULT_WALLET_DAT = "wallet.dat";
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 const uint32_t BIP44_COIN_TYPE = 3;
 
-static bool IsShadowForkMemoryOnlyWallet()
+static bool IsShadowForkWalletRescanSkipped()
 {
     return Params().GetConsensus(0).fShadowForkMode &&
         GetBoolArg("-shadowforkskipwalletrescan", true);
+}
+
+static bool IsShadowForkMemoryOnlyWallet()
+{
+    return Params().GetConsensus(0).fShadowForkMode &&
+        GetBoolArg("-shadowforkmemoryonlywallet", false);
 }
 
 /**
@@ -1568,7 +1574,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool f
     {
         LOCK2(cs_main, cs_wallet);
 
-        if (IsShadowForkMemoryOnlyWallet()) {
+        if (IsShadowForkWalletRescanSkipped()) {
             LogPrintf("%s: shadow fork mode: skipped wallet rescan from height=%d tip=%d\n",
                 __func__,
                 pindex ? pindex->nHeight : -1,
@@ -3852,6 +3858,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
         // Shadowfork datadirs are cloned from an already-synced frozen base, so
         // the wallet's persisted locator should not drive a rescan decision here.
         LogPrintf("Shadowfork wallet init: using active tip directly and skipping locator-based rescan selection\n");
+        walletInstance->SetBestChain(GetWalletBestChainLocator());
     } else if (GetBoolArg("-rescan", false))
         pindexRescan = chainActive.Genesis();
     else
@@ -3860,7 +3867,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
         CBlockLocator locator;
         if (walletdb.ReadBestBlock(locator)) {
             pindexRescan = FindForkInGlobalIndex(chainActive, locator);
-            if (IsShadowForkMemoryOnlyWallet() && pindexRescan != chainActive.Tip()) {
+            if (IsShadowForkWalletRescanSkipped() && pindexRescan != chainActive.Tip()) {
                 LogPrintf("Shadow fork wallet rescan skipped: wallet best fork height=%d, active tip height=%d\n",
                     pindexRescan ? pindexRescan->nHeight : -1,
                     chainActive.Tip() ? chainActive.Tip()->nHeight : -1);


### PR DESCRIPTION
## Summary
- add a shadowfork-only block-index snapshot that stores the active chain and loads only a recent window eagerly
- lazily materialize older active-chain entries on demand so startup does not rebuild the full inherited block index
- keep snapshot loading opt-out and preserve fallback to the normal `blocks/index` path when the snapshot is missing or unusable

## Changes
- add `src/shadowfork_snapshot.{h,cpp}` with a versioned snapshot format and reader/writer
- add `-buildshadowforksnapshot`, `-shadowforkusesnapshot`, `-shadowforksnapshotroot`, and `-shadowforksnapshotwindow`
- load the shadowfork block index from the shared snapshot first, then apply a small delta from `blocks/index` above the snapshot tip
- eagerly materialize only the newest active-chain window and lazy-load older active-chain entries by height/hash when RPCs or wallet flows touch them
- add `CChain::SetTipWindow()` so `chainActive` can be initialized without preloading the whole historical chain
- teach RPC and wallet paths to resolve older active-chain entries through the lazy loader
- short-circuit shadowfork versionbits history scans and the expensive BIP34 ancestor walk in `TestBlockValidity()`
- skip local PoW verification for instant-mined shadowfork blocks when reading them back from disk so `getblock` works on locally mined fork blocks
- keep lazily loaded active-chain ancestry contiguous so chunk-boundary parents are never left detached
- only synthesize `previousblockhash` from `chainActive` for blocks actually on the active chain

## Validation
- built the Linux `dogecoind` binary in an OrbStack `amd64` container after the final fixes
- validated on a restored AWS test volume, not the live source volume
- built a snapshot from the source chain and started a manual shadowfork from the restored data
- verified `getblockchaininfo`, mining, wallet send + confirm, `getblock`, clean restart persistence, pre-fork wallet/account queries, and basic script funding via a 1-of-1 multisig address
- measured startup on the restored fork:
  - fresh fork datadir: about `20s` to `Done loading`, with block-index load around `3.3s`
  - clean restart: snapshot load around `436ms`, block-index around `471ms`

## Notes
- this is shadowfork-only; it does not change normal main/test startup behavior
- the snapshot path is default-on in the custom node but remains opt-out with `-noshadowforkusesnapshot`
- the orchestrator can disable it per create request via `"disabled_features": ["snapshot"]`
