### PR TITLE
Fix shadowfork mining across startup-cut history

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -197,8 +197,17 @@ const CBlockIndex* CBlockIndex::GetAncestor(int height) const
 
 void CBlockIndex::BuildSkip()
 {
-    if (pprev)
-        pskip = pprev->GetAncestor(GetSkipHeight(nHeight));
+    if (!pprev) {
+        return;
+    }
+
+    const int skip_height = GetSkipHeight(nHeight);
+    if (IsBelowShadowForkStartupCutWindow(skip_height)) {
+        pskip = NULL;
+        return;
+    }
+
+    pskip = pprev->GetAncestor(skip_height);
 }
 
 arith_uint256 GetBlockProof(const CBlockIndex& block)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -511,9 +511,12 @@ public:
         vSeeds.clear();
         vFixedSeeds.clear();
 
-        // Dev-friendly flags (like regtest)
+        // Dev-friendly flags. Keep expensive consistency checks disabled by
+        // default: shadowforks can inherit tens of millions of source-chain
+        // blocks through the lazy snapshot index, and regtest-style
+        // CheckBlockIndex passes can stall every mined block for minutes.
         fMiningRequiresPeers = false;
-        fDefaultConsistencyChecks = true;
+        fDefaultConsistencyChecks = false;
         fRequireStandard = false;
         fMineBlocksOnDemand = true;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -155,7 +155,7 @@ namespace {
             g_shadowfork_lazy_block_index.active_tip_height == g_shadowfork_lazy_block_index.eager_base_height;
     }
 
-    bool IsBelowShadowForkStartupCutWindow(int height)
+    bool IsBelowShadowForkStartupCutWindowInternal(int height)
     {
         return IsShadowForkStartupCutLazyWindow() &&
             height >= 0 &&
@@ -243,6 +243,11 @@ namespace {
     /** Dirty block file entries. */
     std::set<int> setDirtyFileInfo;
 } // anon namespace
+
+bool IsBelowShadowForkStartupCutWindow(int height)
+{
+    return IsBelowShadowForkStartupCutWindowInternal(height);
+}
 
 /* Use this class to start tracking transactions that are removed from the
  * mempool and pass all those transactions through SyncTransaction when the

--- a/src/validation.h
+++ b/src/validation.h
@@ -334,6 +334,8 @@ CBlockIndex * InsertBlockIndex(uint256 hash);
 CBlockIndex* FindLoadedBlockIndex(const uint256& hash);
 /** Return a loaded block index entry, lazily materializing active-chain entries in shadowfork mode when needed. */
 CBlockIndex* LookupBlockIndex(const uint256& hash);
+/** True when a height is below the intentionally loaded shadowfork startup-cut active-chain window. */
+bool IsBelowShadowForkStartupCutWindow(int height);
 /** Flush all state, indexes and buffers to disk. */
 void FlushStateToDisk();
 /** Prune block files and flush state to disk. */


### PR DESCRIPTION
## Summary

This PR fixes shadowfork mining behavior when a node is started from a `-shadowforkstartupcut` height that sits above the lazy active-chain snapshot window.

It is stacked on #8 and is shadowfork-only.

## Changes

- Avoid building skip pointers whose target height is below the startup-cut lazy window.
- Expose the startup-cut window predicate so validation can distinguish intentionally missing skip pointers from corrupt block-index state.
- Relax the `CheckBlockIndex` skip-pointer invariant for snapshot-loaded shadowfork active-chain entries below the startup-cut window.
- Disable expensive default consistency checks for shadowfork chainparams while keeping explicit checks available.

## Validation

- `git diff --check`
- Built amd64 Docker runtime image from the rebased PR head:
  - `vladogeos/dogecoin-shadow-runtime:pr9-reviewfix-20260511`
  - `vladogeos/dogecoin-shadow-runtime:pr9-reviewfix-a2659206a`
- Smoke checked the image with `dogecoind --version`.
- GitHub CI was restarted after the rebase; quick subtree/translation checks were passing when last checked, with the larger matrix still running.

## Scope

This does not change normal Dogecoin mainnet/testnet behavior. The modified paths are guarded by shadowfork chainparams/startup-cut snapshot behavior.
