### PR TITLE
fix: add trusted shadowfork startup cut

### DIFF
--- a/qa/rpc-tests/shadowfork.py
+++ b/qa/rpc-tests/shadowfork.py
@@ -17,7 +17,10 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
+    assert_raises_message,
+    JSONRPCException,
     start_node,
+    stop_node,
     connect_nodes_bi,
     hex_str_to_bytes,
     bytes_to_hex_str,
@@ -27,6 +30,7 @@ from test_framework.util import (
 )
 import os
 import logging
+import subprocess
 from test_framework.mininode import CTransaction, CTxIn, CTxOut, COutPoint, sha256
 from test_framework.script import CScript, OP_CHECKSIG, OP_DUP, OP_HASH160, OP_EQUALVERIFY
 
@@ -74,6 +78,12 @@ class ShadowForkTest(BitcoinTestFramework):
 
     def run_test(self):
         """Run all shadow fork tests."""
+        self.log.info("Testing memory-only wallet mode...")
+        self.test_memory_only_wallet()
+
+        self.log.info("Testing trusted startup cut fail-closed markers...")
+        self.test_trusted_startup_cut_fail_closed()
+
         self.log.info("Testing shadow fork initialization...")
         self.test_shadowfork_init()
 
@@ -95,6 +105,88 @@ class ShadowForkTest(BitcoinTestFramework):
 
         # Should start with genesis block
         assert_greater_than(info['blocks'], -1)
+
+    def test_memory_only_wallet(self):
+        """Test that generated keys are retained only in memory."""
+        stop_node(self.nodes[0], 0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-shadowforkmemoryonlywallet=1"])
+
+        node = self.nodes[0]
+        addr = node.getnewaddress()
+        assert_equal(node.validateaddress(addr)['ismine'], True)
+        node.setaccount(addr, "memory-only")
+        assert_equal(node.getaccount(addr), "memory-only")
+        assert_raises_message(
+            JSONRPCException,
+            "encryptwallet is disabled for shadow fork memory-only wallets",
+            node.encryptwallet,
+            "temporary-passphrase",
+        )
+        node.keypoolrefill(1)
+
+        stop_node(node, 0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, [])
+        assert_equal(self.nodes[0].validateaddress(addr)['ismine'], False)
+        assert_equal(self.nodes[0].getaccount(addr), "")
+
+    def assert_node_start_fails(self, extra_args, expected_text):
+        """Start dogecoind directly and assert initialization exits with an expected message."""
+        datadir = os.path.join(self.options.tmpdir, "node0")
+        binary = os.getenv("DOGECOIND", os.path.join(self.options.srcdir, "dogecoind"))
+        args = [
+            binary,
+            "-datadir=" + datadir,
+            "-server",
+            "-keypool=1",
+            "-discover=0",
+            "-rest",
+        ] + extra_args
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        try:
+            stdout, stderr = proc.communicate(timeout=20)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            stdout, stderr = proc.communicate(timeout=5)
+            raise AssertionError("dogecoind unexpectedly stayed running: %s\n%s%s" % (args, stdout, stderr))
+
+        if proc.returncode == 0:
+            raise AssertionError("dogecoind unexpectedly started successfully: %s" % (args,))
+
+        logs = stdout + stderr
+        for relpath in ("shadowfork/debug.log", "debug.log"):
+            path = os.path.join(datadir, relpath)
+            if os.path.exists(path):
+                with open(path, encoding="utf8", errors="replace") as f:
+                    logs += f.read()
+        if expected_text not in logs:
+            raise AssertionError("missing expected startup failure %r in:\n%s" % (expected_text, logs[-4000:]))
+
+    def test_trusted_startup_cut_fail_closed(self):
+        """Test trusted startup-cut datadir markers must be reused with matching flags."""
+        node = self.nodes[0]
+        addr = node.getnewaddress()
+        node.generatetoaddress(3, addr)
+
+        stop_node(node, 0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-shadowfork=1"])
+        stop_node(self.nodes[0], 0)
+
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-shadowfork=1", "-shadowforktruststartupcut=1"])
+        stop_node(self.nodes[0], 0)
+
+        expected = "datadir contains a chainstate marker written by -shadowforktruststartupcut"
+        self.assert_node_start_fails(["-shadowfork=1"], expected)
+        self.assert_node_start_fails(["-shadowfork=2", "-shadowforktruststartupcut=1"], expected)
+
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-shadowfork=1", "-shadowforktruststartupcut=1"])
+        node = self.nodes[0]
+        post_cut_addr = node.getnewaddress()
+        post_cut_block = node.generatetoaddress(1, post_cut_addr)[0]
+        assert_equal(node.getbestblockhash(), post_cut_block)
+
+        stop_node(node, 0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-shadowfork=1", "-shadowforktruststartupcut=1"])
+        assert_equal(self.nodes[0].getbestblockhash(), post_cut_block)
 
     def test_trivial_mining(self):
         """Test that mining works with trivial PoW."""

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -488,8 +488,9 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-shadowforksnapshotroot=<dir>", _("Root directory for shared shadow fork snapshots; defaults to the nearest ancestor shadow-snapshots directory or <datadir>/shadow-snapshots"));
         strUsage += HelpMessageOpt("-shadowforksnapshotwindow=<n>", _("Eagerly load the newest <n> active-chain block-index entries from the snapshot at startup, lazily loading older active-chain entries on demand (default: 8192)"));
         strUsage += HelpMessageOpt("-shadowforkstartupcut", _("In shadow fork mode, cut the active chain to -shadowfork=<height> during startup instead of requiring external invalidateblock rollback (default: 1)"));
+        strUsage += HelpMessageOpt("-shadowforktruststartupcut", _("In shadow fork mode, trust the prepared-volume UTXO snapshot when cutting to -shadowfork=<height>, without undo-replaying inherited source blocks. Intended only for isolated test runtimes that spend post-fork outputs; do not enable on nodes connected to real networks because chainstate will not match consensus history (default: 0)"));
         strUsage += HelpMessageOpt("-shadowforkskipwalletrescan", _("In shadow fork mode, trust the startup-cut tip and skip stale inherited wallet rescans (default: 1)"));
-        strUsage += HelpMessageOpt("-shadowforkmemoryonlywallet", _("In shadow fork mode, skip wallet transaction DB loads and keep wallet changes in memory only (default: 0)"));
+        strUsage += HelpMessageOpt("-shadowforkmemoryonlywallet", _("In shadow fork mode, skip wallet transaction DB loads and keep wallet-generated state in memory only, including transactions, address/account metadata, keys, keypool, and HD counters. Intended only for isolated test runtimes; do not later reuse generated addresses with this flag disabled (default: 0)"));
     }
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
@@ -951,6 +952,29 @@ bool AppInitParameterInteraction()
 
         LogPrintf("Shadow fork mode enabled: forking from %s at height %d, maturity=%d\n",
                   sourceChain, nForkHeight, nMaturity);
+    }
+
+    if (GetBoolArg("-shadowforktruststartupcut", false)) {
+        if (!chainparams.GetConsensus(0).fShadowForkMode) {
+            return InitError(_("-shadowforktruststartupcut requires shadow fork mode."));
+        }
+        if (GetArg("-shadowfork", -1) <= 0) {
+            return InitError(_("-shadowforktruststartupcut requires a positive -shadowfork height."));
+        }
+        if (!GetBoolArg("-shadowforkstartupcut", true)) {
+            return InitError(_("-shadowforktruststartupcut requires -shadowforkstartupcut."));
+        }
+        const std::string warning = _("Trusted shadow fork startup cut enabled; inherited chainstate will not be undo-replayed to the requested fork height. The persisted chainstate best-block marker will point at the fork height while UTXO contents remain prepared-volume test state with post-fork source-chain creates/spends. This is only for isolated test runtimes and must not be used on nodes connected to real networks.");
+        InitWarning(warning);
+        LogPrintf("WARNING: %s\n", warning);
+    }
+    if (GetBoolArg("-shadowforkmemoryonlywallet", false)) {
+        if (!chainparams.GetConsensus(0).fShadowForkMode) {
+            return InitError(_("-shadowforkmemoryonlywallet requires shadow fork mode."));
+        }
+        const std::string warning = _("Shadow fork memory-only wallet enabled; wallet-generated state including transactions, address/account metadata, keys, keypool, and HD counters will not be persisted. Do not reuse addresses generated in this mode after restarting without -shadowforkmemoryonlywallet.");
+        InitWarning(warning);
+        LogPrintf("WARNING: %s\n", warning);
     }
 
     // if using block pruning, then disallow txindex

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -111,6 +111,13 @@ void AskPassphraseDialog::accept()
             // Cannot encrypt with empty passphrase
             break;
         }
+        if(model->isShadowForkMemoryOnly())
+        {
+            QMessageBox::critical(this, tr("Wallet encryption disabled"),
+                                  tr("Wallet encryption is disabled for shadow fork memory-only wallets because encrypted keys and master keys would require wallet database writes."));
+            QDialog::reject();
+            break;
+        }
         QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm wallet encryption"),
                  tr("Warning: If you encrypt your wallet and lose your passphrase, you will <b>LOSE ALL OF YOUR DOGECOINS</b>!") + "<br><br>" + tr("Are you sure you wish to encrypt your wallet?"),
                  QMessageBox::Yes|QMessageBox::Cancel,
@@ -175,6 +182,13 @@ void AskPassphraseDialog::accept()
         }
         break;
     case ChangePass:
+        if(model->isShadowForkMemoryOnly())
+        {
+            QMessageBox::critical(this, tr("Wallet passphrase change disabled"),
+                                  tr("Wallet passphrase changes are disabled for shadow fork memory-only wallets because updated master keys would require wallet database writes."));
+            QDialog::reject();
+            break;
+        }
         if(newpass1 == newpass2)
         {
             if(model->changePassphrase(oldpass, newpass1))

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -385,6 +385,11 @@ bool WalletModel::setWalletEncrypted(bool encrypted, const SecureString &passphr
     }
 }
 
+bool WalletModel::isShadowForkMemoryOnly() const
+{
+    return wallet->IsShadowForkMemoryOnly();
+}
+
 bool WalletModel::setWalletLocked(bool locked, const SecureString &passPhrase)
 {
     if(locked)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -150,6 +150,7 @@ public:
     SendCoinsReturn sendCoins(WalletModelTransaction &transaction);
 
     // Wallet encryption
+    bool isShadowForkMemoryOnly() const;
     bool setWalletEncrypted(bool encrypted, const SecureString &passphrase);
     // Passphrase only needed when unlocking
     bool setWalletLocked(bool locked, const SecureString &passPhrase=SecureString());

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -8,6 +8,7 @@
 #include "uint256.h"
 #include "random.h"
 #include "test/test_bitcoin.h"
+#include "txdb.h"
 
 #include <boost/assign/std/vector.hpp> // for 'operator+=()'
 #include <boost/assert.hpp>
@@ -81,6 +82,42 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
         // key3 should've never been written
         BOOST_CHECK(dbw.Read(key3, res) == false);
     }
+}
+
+BOOST_AUTO_TEST_CASE(blocktree_flag_helpers)
+{
+    CBlockTreeDB dbw(1 << 20, true);
+
+    bool flag = true;
+    BOOST_CHECK(!dbw.ReadFlag("missing", flag));
+    BOOST_CHECK_EQUAL(flag, true);
+    BOOST_CHECK(!dbw.ExistsFlag("missing"));
+
+    BOOST_CHECK(dbw.WriteFlag("trusted-cut", true, true));
+    flag = false;
+    BOOST_CHECK(dbw.ExistsFlag("trusted-cut"));
+    BOOST_CHECK(dbw.ReadFlag("trusted-cut", flag));
+    BOOST_CHECK_EQUAL(flag, true);
+
+    BOOST_CHECK(dbw.WriteFlag("trusted-cut", false, true));
+    flag = true;
+    BOOST_CHECK(dbw.ReadFlag("trusted-cut", flag));
+    BOOST_CHECK_EQUAL(flag, false);
+
+    int height = -1;
+    BOOST_CHECK(dbw.WriteFlagInt("trusted-cut-height", 42, true));
+    BOOST_CHECK(dbw.ReadFlagInt("trusted-cut-height", height));
+    BOOST_CHECK_EQUAL(height, 42);
+    BOOST_CHECK(dbw.EraseFlag("trusted-cut-height", true));
+    BOOST_CHECK(!dbw.ExistsFlag("trusted-cut-height"));
+
+    BOOST_CHECK(dbw.Write(std::make_pair(static_cast<char>('F'), std::string("bad-flag")), static_cast<char>('x'), true));
+    flag = true;
+    BOOST_CHECK(!dbw.ReadFlag("bad-flag", flag));
+    BOOST_CHECK_EQUAL(flag, true);
+    height = -1;
+    BOOST_CHECK(!dbw.ReadFlagInt("bad-flag", height));
+    BOOST_CHECK_EQUAL(height, -1);
 }
 
 BOOST_AUTO_TEST_CASE(dbwrapper_iterator)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -165,15 +165,42 @@ bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos>
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::WriteFlag(const std::string &name, bool fValue) {
-    return Write(std::make_pair(DB_FLAG, name), fValue ? '1' : '0');
+bool CBlockTreeDB::WriteFlag(const std::string &name, bool fValue, bool fSync) {
+    return Write(std::make_pair(DB_FLAG, name), fValue ? '1' : '0', fSync);
 }
 
 bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue) {
     char ch;
     if (!Read(std::make_pair(DB_FLAG, name), ch))
         return false;
-    fValue = ch == '1';
+    // WriteFlag stores single-byte ASCII booleans; any other value means the
+    // marker is corrupted and callers should fail closed.
+    if (ch == '1') {
+        fValue = true;
+        return true;
+    }
+    if (ch == '0') {
+        fValue = false;
+        return true;
+    }
+    return false;
+}
+
+bool CBlockTreeDB::ExistsFlag(const std::string &name) {
+    return Exists(std::make_pair(DB_FLAG, name));
+}
+
+bool CBlockTreeDB::EraseFlag(const std::string &name, bool fSync) {
+    return Erase(std::make_pair(DB_FLAG, name), fSync);
+}
+
+bool CBlockTreeDB::WriteFlagInt(const std::string &name, int nValue, bool fSync) {
+    return Write(std::make_pair(DB_FLAG, name), nValue, fSync);
+}
+
+bool CBlockTreeDB::ReadFlagInt(const std::string &name, int &nValue) {
+    if (!Read(std::make_pair(DB_FLAG, name), nValue))
+        return false;
     return true;
 }
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -120,8 +120,12 @@ public:
     bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
     bool ReadBlockIndex(const uint256 &hash, CDiskBlockIndex &diskindex);
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
-    bool WriteFlag(const std::string &name, bool fValue);
+    bool WriteFlag(const std::string &name, bool fValue, bool fSync = false);
     bool ReadFlag(const std::string &name, bool &fValue);
+    bool ExistsFlag(const std::string &name);
+    bool EraseFlag(const std::string &name, bool fSync = false);
+    bool WriteFlagInt(const std::string &name, int nValue, bool fSync = false);
+    bool ReadFlagInt(const std::string &name, int &nValue);
     bool LoadBlockIndexGuts(std::function<CBlockIndex*(const uint256&)> insertBlockIndex);
 };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -101,10 +101,20 @@ namespace {
 
     static const int DEFAULT_SHADOWFORK_SNAPSHOT_WINDOW = 8192;
     static const int SHADOWFORK_LAZY_ACTIVE_CHAIN_CHUNK = 256;
+    static const char* SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG = "shadowforktruststartupcut";
+    static const char* SHADOWFORK_TRUSTED_STARTUP_CUT_HEIGHT_FLAG = "shadowforktruststartupcutheight";
 
     bool IsShadowForkOptimizationEnabled(const CChainParams& params, const char* arg)
     {
         return params.GetConsensus(0).fShadowForkMode && GetBoolArg(arg, true);
+    }
+
+    bool IsTrustedShadowForkStartupCutRequested(const CChainParams& params)
+    {
+        return params.GetConsensus(0).fShadowForkMode &&
+            GetBoolArg("-shadowforktruststartupcut", false) &&
+            GetBoolArg("-shadowforkstartupcut", true) &&
+            GetArg("-shadowfork", -1) > 0;
     }
 
     bool IsShadowForkInstantMiningEnabled(const Consensus::Params& consensusParams)
@@ -3811,11 +3821,13 @@ static void TrackLoadedBlockIndexEntry(CBlockIndex* pindex, bool fShadowForkFast
     }
 }
 
-static size_t RemoveLoadedBlockIndexEntriesAboveHeight(int height)
+static size_t RemoveLoadedBlockIndexEntriesAboveHeight(int height, bool fKeepActiveChain = false)
 {
     std::vector<BlockMap::iterator> entries_to_remove;
     for (BlockMap::iterator it = mapBlockIndex.begin(); it != mapBlockIndex.end(); ++it) {
-        if (it->second != NULL && it->second->nHeight > height) {
+        if (it->second != NULL &&
+            it->second->nHeight > height &&
+            (!fKeepActiveChain || !chainActive.Contains(it->second))) {
             entries_to_remove.push_back(it);
         }
     }
@@ -4524,6 +4536,33 @@ bool static LoadBlockIndexDBFromLevelDB(const CChainParams& chainparams)
 
 bool static LoadBlockIndexDB(const CChainParams& chainparams)
 {
+    bool fTrustedStartupCutDatadir = false;
+    const bool fTrustedStartupCutFlagExists = pblocktree->ExistsFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG);
+    const bool fTrustedStartupCutHeightExists = pblocktree->ExistsFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_HEIGHT_FLAG);
+    if (fTrustedStartupCutFlagExists) {
+        if (!pblocktree->ReadFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG, fTrustedStartupCutDatadir)) {
+            return error("%s: trusted shadow fork startup-cut marker is corrupted; rebuild the datadir", __func__);
+        }
+    }
+    if (!fTrustedStartupCutDatadir && fTrustedStartupCutHeightExists) {
+        return error("%s: trusted shadow fork startup-cut height marker exists without an active marker; rebuild the datadir",
+            __func__);
+    }
+    if (fTrustedStartupCutDatadir) {
+        int trusted_cut_height = -1;
+        if (!fTrustedStartupCutHeightExists ||
+            !pblocktree->ReadFlagInt(SHADOWFORK_TRUSTED_STARTUP_CUT_HEIGHT_FLAG, trusted_cut_height) ||
+            trusted_cut_height <= 0) {
+            return error("%s: trusted shadow fork startup-cut height marker is missing, corrupted, or non-positive; rebuild the datadir",
+                __func__);
+        }
+        if (!IsTrustedShadowForkStartupCutRequested(chainparams) ||
+            GetArg("-shadowfork", -1) != trusted_cut_height) {
+            return error("%s: datadir contains a chainstate marker written by -shadowforktruststartupcut at height %d; restart with shadow fork mode, -shadowforkstartupcut, -shadowforktruststartupcut, and -shadowfork=%d, or rebuild the datadir",
+                __func__, trusted_cut_height, trusted_cut_height);
+        }
+    }
+
     if (TryLoadShadowForkSnapshot(chainparams)) {
         return true;
     }
@@ -4797,20 +4836,164 @@ bool ApplyShadowForkStartupCut(const CChainParams& chainparams)
             __func__, requested_height);
     }
 
-    const int loaded_height = chainActive.Height();
-    const uint256 loaded_hash = chainActive.Tip()->GetBlockHash();
+    CBlockIndex* loaded_tip = chainActive.Tip();
+    const int old_window_start_height = chainActive.WindowStartHeight();
+    const int loaded_height = loaded_tip->nHeight;
+    const uint256 loaded_hash = loaded_tip->GetBlockHash();
     const uint256 old_coins_best = pcoinsTip->GetBestBlock();
+    const bool fTrustedStartupCut = GetBoolArg("-shadowforktruststartupcut", false);
+    bool fTrustedStartupCutDatadir = false;
+    if (fTrustedStartupCut && pblocktree->ExistsFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG)) {
+        if (!pblocktree->ReadFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG, fTrustedStartupCutDatadir)) {
+            return error("%s: trusted shadow fork startup-cut marker is corrupted; rebuild the datadir", __func__);
+        }
+        if (fTrustedStartupCutDatadir) {
+            int trusted_cut_height = -1;
+            if (!pblocktree->ReadFlagInt(SHADOWFORK_TRUSTED_STARTUP_CUT_HEIGHT_FLAG, trusted_cut_height) ||
+                trusted_cut_height != requested_height) {
+                return error("%s: trusted shadow fork startup-cut marker height does not match requested height %d; rebuild the datadir",
+                    __func__, requested_height);
+            }
+        }
+    }
     if (requested_height == loaded_height) {
         if (old_coins_best != target->GetBlockHash()) {
             return error("%s: active tip already at requested height %d but coins best is %s, expected %s; refusing unsafe shadow fork cut",
                 __func__, requested_height, old_coins_best.ToString(), target->GetBlockHash().ToString());
         }
-        LogPrintf("%s: loaded source tip already matches requested shadow fork height %d (%s)\n",
+        if (fTrustedStartupCut && !fTrustedStartupCutDatadir) {
+            const bool fWroteHeight = pblocktree->WriteFlagInt(SHADOWFORK_TRUSTED_STARTUP_CUT_HEIGHT_FLAG, target->nHeight, true);
+            const bool fWroteMarker = fWroteHeight && pblocktree->WriteFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG, true, true);
+            if (!fWroteHeight || !fWroteMarker) {
+                const bool fErasedHeight = pblocktree->EraseFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_HEIGHT_FLAG, true);
+                const bool fErasedMarker = pblocktree->EraseFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG, true);
+                return error("%s: failed to mark datadir as using trusted shadow fork startup cut%s%s",
+                    __func__,
+                    fErasedHeight ? "" : "; also failed to erase partial trusted-cut height marker",
+                    fErasedMarker ? "" : "; also failed to erase partial trusted-cut active marker");
+            }
+        }
+        LogPrintf("%s: loaded source tip already matches requested shadow fork height %d (%s); trusted startup cut has no inherited blocks to skip on this run\n",
             __func__, requested_height, target->GetBlockHash().ToString());
         return true;
     }
 
     CValidationState state;
+    if (fTrustedStartupCut) {
+        const auto restore_loaded_tip = [&]() {
+            if (g_shadowfork_lazy_block_index.enabled) {
+                chainActive.SetTipWindow(loaded_tip, old_window_start_height);
+            } else {
+                chainActive.SetTip(loaded_tip);
+            }
+        };
+        const uint256 target_hash = target->GetBlockHash();
+        const bool fCoinsAlreadyAtTarget = old_coins_best == target_hash;
+        const bool fCoinsAtLoadedTip = old_coins_best == loaded_hash;
+        if (!fCoinsAlreadyAtTarget && !fCoinsAtLoadedTip) {
+            return error("%s: trusted shadow fork cut requires coins best to match either loaded source tip %s or requested target %s, got %s",
+                __func__, loaded_hash.ToString(), target_hash.ToString(), old_coins_best.ToString());
+        }
+        if (fTrustedStartupCutDatadir && loaded_height > requested_height) {
+            if (!chainActive.Contains(target)) {
+                return error("%s: trusted shadow fork datadir is already marked but loaded active chain does not contain requested height %d",
+                    __func__, requested_height);
+            }
+            pindexBestHeader = loaded_tip;
+            const size_t removed_above_cut = RemoveLoadedBlockIndexEntriesAboveHeight(target->nHeight, true);
+            if (fCoinsAlreadyAtTarget) {
+                if (g_shadowfork_lazy_block_index.enabled) {
+                    chainActive.SetTipWindow(target, target->nHeight);
+                    g_shadowfork_lazy_block_index.active_tip_height = target->nHeight;
+                    g_shadowfork_lazy_block_index.eager_base_height = target->nHeight;
+                } else {
+                    chainActive.SetTip(target);
+                }
+            }
+            setBlockIndexCandidates.clear();
+            setBlockIndexCandidates.insert(loaded_tip);
+            mempool.AddTransactionsUpdated(1);
+            cvBlockChange.notify_all();
+            LogPrintf("%s: trusted shadow fork startup cut was already applied at height=%d; keeping loaded above-cut candidate height=%d hash=%s with coins best %s and removed %u non-active above-cut block index entries\n",
+                __func__, target->nHeight, loaded_tip->nHeight, loaded_hash.ToString(),
+                old_coins_best.ToString(),
+                static_cast<unsigned int>(removed_above_cut));
+            return true;
+        }
+
+        LogPrintf("WARNING: %s: applying trusted shadow fork startup cut from height=%d hash=%s to height=%d hash=%s without disconnecting %d inherited source blocks; the persisted chainstate best-block marker will point at the fork height while UTXO contents remain trusted prepared-volume test state reflecting creates/spends from source-chain blocks above the cut. Do not use this mode on nodes connected to real networks.\n",
+            __func__, loaded_height, loaded_hash.ToString(), target->nHeight,
+            target_hash.ToString(), loaded_height - target->nHeight);
+
+        if (g_shadowfork_lazy_block_index.enabled) {
+            chainActive.SetTipWindow(target, target->nHeight);
+        } else {
+            // Without the lazy snapshot loader, ancestor lookups below the cut
+            // must remain backed by the eagerly populated in-memory chain.
+            chainActive.SetTip(target);
+        }
+        bool fWroteMarkersThisRun = false;
+        if (!fTrustedStartupCutDatadir) {
+            const bool fWroteHeight = pblocktree->WriteFlagInt(SHADOWFORK_TRUSTED_STARTUP_CUT_HEIGHT_FLAG, target->nHeight, true);
+            const bool fWroteMarker = fWroteHeight && pblocktree->WriteFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG, true, true);
+            fWroteMarkersThisRun = fWroteHeight && fWroteMarker;
+            if (!fWroteMarkersThisRun) {
+                const bool fErasedHeight = pblocktree->EraseFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_HEIGHT_FLAG, true);
+                const bool fErasedMarker = pblocktree->EraseFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG, true);
+                restore_loaded_tip();
+                return error("%s: failed to mark datadir as using trusted shadow fork startup cut%s%s",
+                    __func__,
+                    fErasedHeight ? "" : "; also failed to erase partial trusted-cut height marker",
+                    fErasedMarker ? "" : "; also failed to erase partial trusted-cut active marker");
+            }
+        }
+        if (!fCoinsAlreadyAtTarget) {
+            pcoinsTip->SetBestBlock(target_hash);
+        }
+        if (!FlushStateToDisk(state, FLUSH_STATE_ALWAYS)) {
+            bool fCleanupOk = true;
+            if (!fCoinsAlreadyAtTarget) {
+                pcoinsTip->SetBestBlock(old_coins_best);
+            }
+            if (fWroteMarkersThisRun) {
+                const bool fErasedHeight = pblocktree->EraseFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_HEIGHT_FLAG, true);
+                const bool fErasedMarker = pblocktree->EraseFlag(SHADOWFORK_TRUSTED_STARTUP_CUT_FLAG, true);
+                fCleanupOk = fErasedHeight && fErasedMarker;
+                if (!fCleanupOk) {
+                    LogPrintf("%s: failed to fully erase trusted shadow fork startup-cut markers after chainstate flush failure; erased_height=%d erased_marker=%d; datadir may fail closed on the next start\n",
+                        __func__, fErasedHeight ? 1 : 0, fErasedMarker ? 1 : 0);
+                } else {
+                    LogPrintf("%s: erased trusted shadow fork startup-cut markers after chainstate flush failure\n",
+                        __func__);
+                }
+            }
+            restore_loaded_tip();
+            return error("%s: failed to flush trusted shadow fork chainstate marker after startup cut%s",
+                __func__, fCleanupOk ? "" : "; marker cleanup also failed and the datadir may fail closed on the next start");
+        }
+
+        pindexBestHeader = target;
+        if (g_shadowfork_lazy_block_index.enabled) {
+            g_shadowfork_lazy_block_index.active_tip_height = target->nHeight;
+            g_shadowfork_lazy_block_index.eager_base_height = target->nHeight;
+        }
+        const size_t removed_above_cut = RemoveLoadedBlockIndexEntriesAboveHeight(target->nHeight);
+
+        setBlockIndexCandidates.clear();
+        setBlockIndexCandidates.insert(target);
+        // The trusted path intentionally skips DisconnectTip's transaction
+        // removal signals and mempool resurrection because the prepared-volume
+        // UTXO set is accepted as authoritative synthetic shadowfork state.
+        mempool.clear();
+        mempool.AddTransactionsUpdated(1);
+        cvBlockChange.notify_all();
+
+        LogPrintf("%s: trusted shadow fork startup cut complete; coins best now at %s (was %s); removed %u loaded above-cut block index entries\n",
+            __func__, pcoinsTip->GetBestBlock().ToString(), old_coins_best.ToString(),
+            static_cast<unsigned int>(removed_above_cut));
+        return true;
+    }
+
     int disconnected = 0;
     while (chainActive.Height() > requested_height) {
         if (!DisconnectTip(state, chainparams, true)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -59,6 +59,19 @@ void EnsureWalletIsUnlocked()
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 }
 
+static void ThrowKeyGenerationError()
+{
+    if (pwalletMain->IsShadowForkMemoryOnly()) {
+        if (pwalletMain->IsLocked()) {
+            throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED,
+                "Error: Shadow fork memory-only wallet is locked; enter the wallet passphrase before generating an in-memory key.");
+        }
+        throw JSONRPCError(RPC_WALLET_ERROR,
+            "Error: Shadow fork memory-only wallet could not generate an in-memory key; see debug.log.");
+    }
+    throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+}
+
 void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
 {
     int confirms = wtx.GetDepthInMainChain();
@@ -142,7 +155,7 @@ UniValue getnewaddress(const JSONRPCRequest& request)
     // Generate a new key that is added to wallet
     CPubKey newKey;
     if (!pwalletMain->GetKeyFromPool(newKey))
-        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+        ThrowKeyGenerationError();
     CKeyID keyID = newKey.GetID();
 
     pwalletMain->SetAddressBook(keyID, strAccount, "receive");
@@ -155,7 +168,7 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 {
     CPubKey pubKey;
     if (!pwalletMain->GetAccountPubkey(pubKey, strAccount, bForceNew)) {
-        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+        ThrowKeyGenerationError();
     }
 
     return CBitcoinAddress(pubKey.GetID());
@@ -218,7 +231,7 @@ UniValue getrawchangeaddress(const JSONRPCRequest& request)
     CReserveKey reservekey(pwalletMain);
     CPubKey vchPubKey;
     if (!reservekey.GetReservedKey(vchPubKey))
-        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+        ThrowKeyGenerationError();
 
     reservekey.KeepKey();
 
@@ -2126,6 +2139,11 @@ UniValue keypoolrefill(const JSONRPCRequest& request)
     }
 
     EnsureWalletIsUnlocked();
+    if (pwalletMain->IsShadowForkMemoryOnly()) {
+        LogPrintf("%s: shadow fork memory-only wallet uses on-demand keys; keypoolrefill is a no-op\n",
+            __func__);
+        return NullUniValue;
+    }
     pwalletMain->TopUpKeyPool(kpSize);
 
     if (pwalletMain->GetKeyPoolSize() < kpSize)
@@ -2241,8 +2259,13 @@ UniValue walletpassphrasechange(const JSONRPCRequest& request)
             "walletpassphrasechange <oldpassphrase> <newpassphrase>\n"
             "Changes the wallet passphrase from <oldpassphrase> to <newpassphrase>.");
 
-    if (!pwalletMain->ChangeWalletPassphrase(strOldWalletPass, strNewWalletPass))
+    if (!pwalletMain->ChangeWalletPassphrase(strOldWalletPass, strNewWalletPass)) {
+        if (pwalletMain->IsShadowForkMemoryOnly()) {
+            throw JSONRPCError(RPC_WALLET_ERROR,
+                "Error: walletpassphrasechange is disabled for shadow fork memory-only wallets because it would persist updated master keys.");
+        }
         throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
+    }
 
     return NullUniValue;
 }
@@ -2334,8 +2357,13 @@ UniValue encryptwallet(const JSONRPCRequest& request)
             "encryptwallet <passphrase>\n"
             "Encrypts the wallet with <passphrase>.");
 
-    if (!pwalletMain->EncryptWallet(strWalletPass))
+    if (!pwalletMain->EncryptWallet(strWalletPass)) {
+        if (pwalletMain->IsShadowForkMemoryOnly()) {
+            throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED,
+                "Error: encryptwallet is disabled for shadow fork memory-only wallets because it would persist encrypted keys and master keys.");
+        }
         throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED, "Error: Failed to encrypt the wallet.");
+    }
 
     // BDB seems to have a bad habit of writing old data into
     // slack space in .dat files; that is bad if the old data is

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -63,6 +63,11 @@ static bool IsShadowForkMemoryOnlyWallet()
         GetBoolArg("-shadowforkmemoryonlywallet", false);
 }
 
+bool CWallet::IsShadowForkMemoryOnly() const
+{
+    return IsShadowForkMemoryOnlyWallet();
+}
+
 /**
  * Fees smaller than this (in satoshi) are considered zero fee (for transaction creation)
  * Override with -mintxfee
@@ -178,7 +183,7 @@ void CWallet::DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret)
     secret = childKey.key;
 
     // update the chain model in the database
-    if (!CWalletDB(strWalletFile).WriteHDChain(hdChain))
+    if (!IsShadowForkMemoryOnlyWallet() && !CWalletDB(strWalletFile).WriteHDChain(hdChain))
         throw std::runtime_error(std::string(__func__) + ": Writing HD chain model failed");
 }
 
@@ -197,7 +202,7 @@ bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
     if (HaveWatchOnly(script))
         RemoveWatchOnly(script);
 
-    if (!fFileBacked)
+    if (!fFileBacked || IsShadowForkMemoryOnlyWallet())
         return true;
     if (!IsCrypted()) {
         return CWalletDB(strWalletFile).WriteKey(pubkey,
@@ -212,7 +217,7 @@ bool CWallet::AddCryptedKey(const CPubKey &vchPubKey,
 {
     if (!CCryptoKeyStore::AddCryptedKey(vchPubKey, vchCryptedSecret))
         return false;
-    if (!fFileBacked)
+    if (!fFileBacked || IsShadowForkMemoryOnlyWallet())
         return true;
     {
         LOCK(cs_wallet);
@@ -257,7 +262,7 @@ bool CWallet::AddCScript(const CScript& redeemScript)
 {
     if (!CCryptoKeyStore::AddCScript(redeemScript))
         return false;
-    if (!fFileBacked)
+    if (!fFileBacked || IsShadowForkMemoryOnlyWallet())
         return true;
     return CWalletDB(strWalletFile).WriteCScript(Hash160(redeemScript), redeemScript);
 }
@@ -308,7 +313,7 @@ bool CWallet::RemoveWatchOnly(const CScript &dest)
         return false;
     if (!HaveWatchOnly())
         NotifyWatchonlyChanged(false);
-    if (fFileBacked)
+    if (fFileBacked && !IsShadowForkMemoryOnlyWallet())
         if (!CWalletDB(strWalletFile).EraseWatchOnly(dest))
             return false;
 
@@ -342,6 +347,12 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
 
 bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase)
 {
+    if (IsShadowForkMemoryOnlyWallet()) {
+        LogPrintf("%s: refusing to persist wallet passphrase change for memory-only wallet\n",
+            __func__);
+        return false;
+    }
+
     bool fWasLocked = IsLocked();
 
     {
@@ -388,6 +399,11 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
 
 void CWallet::SetBestChain(const CBlockLocator& loc)
 {
+    if (IsShadowForkMemoryOnlyWallet()) {
+        LogPrintf("%s: shadow fork mode: updated best block locator in memory without wallet DB write\n",
+            __func__);
+        return;
+    }
     CWalletDB walletdb(strWalletFile);
     walletdb.WriteBestBlock(loc);
 }
@@ -407,7 +423,7 @@ bool CWallet::SetMinVersion(enum WalletFeature nVersion, CWalletDB* pwalletdbIn,
     if (nVersion > nWalletMaxVersion)
         nWalletMaxVersion = nVersion;
 
-    if (fFileBacked)
+    if (fFileBacked && !IsShadowForkMemoryOnlyWallet())
     {
         CWalletDB* pwalletdb = pwalletdbIn ? pwalletdbIn : new CWalletDB(strWalletFile);
         if (nWalletVersion > 40000)
@@ -610,6 +626,12 @@ void CWallet::AddToSpends(const uint256& wtxid)
 
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 {
+    if (IsShadowForkMemoryOnlyWallet()) {
+        LogPrintf("%s: refusing to encrypt memory-only wallet because encrypted keys and master keys would require wallet DB writes\n",
+            __func__);
+        return false;
+    }
+
     if (IsCrypted())
         return false;
 
@@ -711,6 +733,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 DBErrors CWallet::ReorderTransactions()
 {
     LOCK(cs_wallet);
+    const bool fMemoryOnly = IsShadowForkMemoryOnlyWallet();
     CWalletDB walletdb(strWalletFile);
 
     // Old wallets didn't have any defined order for transactions
@@ -748,11 +771,11 @@ DBErrors CWallet::ReorderTransactions()
 
             if (pwtx)
             {
-                if (!walletdb.WriteTx(*pwtx))
+                if (!fMemoryOnly && !walletdb.WriteTx(*pwtx))
                     return DB_LOAD_FAIL;
             }
             else
-                if (!walletdb.WriteAccountingEntry(pacentry->nEntryNo, *pacentry))
+                if (!fMemoryOnly && !walletdb.WriteAccountingEntry(pacentry->nEntryNo, *pacentry))
                     return DB_LOAD_FAIL;
         }
         else
@@ -772,15 +795,16 @@ DBErrors CWallet::ReorderTransactions()
             // Since we're changing the order, write it back
             if (pwtx)
             {
-                if (!walletdb.WriteTx(*pwtx))
+                if (!fMemoryOnly && !walletdb.WriteTx(*pwtx))
                     return DB_LOAD_FAIL;
             }
             else
-                if (!walletdb.WriteAccountingEntry(pacentry->nEntryNo, *pacentry))
+                if (!fMemoryOnly && !walletdb.WriteAccountingEntry(pacentry->nEntryNo, *pacentry))
                     return DB_LOAD_FAIL;
         }
     }
-    walletdb.WriteOrderPosNext(nOrderPosNext);
+    if (!fMemoryOnly)
+        walletdb.WriteOrderPosNext(nOrderPosNext);
 
     return DB_LOAD_OK;
 }
@@ -801,33 +825,36 @@ int64_t CWallet::IncOrderPosNext(CWalletDB *pwalletdb)
 
 bool CWallet::AccountMove(std::string strFrom, std::string strTo, CAmount nAmount, std::string strComment)
 {
-    CWalletDB walletdb(strWalletFile);
-    if (!walletdb.TxnBegin())
+    const bool fMemoryOnly = IsShadowForkMemoryOnlyWallet();
+    std::unique_ptr<CWalletDB> walletdb;
+    if (!fMemoryOnly)
+        walletdb.reset(new CWalletDB(strWalletFile));
+    if (walletdb && !walletdb->TxnBegin())
         return false;
 
     int64_t nNow = GetAdjustedTime();
 
     // Debit
     CAccountingEntry debit;
-    debit.nOrderPos = IncOrderPosNext(&walletdb);
+    debit.nOrderPos = IncOrderPosNext(walletdb.get());
     debit.strAccount = strFrom;
     debit.nCreditDebit = -nAmount;
     debit.nTime = nNow;
     debit.strOtherAccount = strTo;
     debit.strComment = strComment;
-    AddAccountingEntry(debit, &walletdb);
+    AddAccountingEntry(debit, walletdb.get());
 
     // Credit
     CAccountingEntry credit;
-    credit.nOrderPos = IncOrderPosNext(&walletdb);
+    credit.nOrderPos = IncOrderPosNext(walletdb.get());
     credit.strAccount = strTo;
     credit.nCreditDebit = nAmount;
     credit.nTime = nNow;
     credit.strOtherAccount = strFrom;
     credit.strComment = strComment;
-    AddAccountingEntry(credit, &walletdb);
+    AddAccountingEntry(credit, walletdb.get());
 
-    if (!walletdb.TxnCommit())
+    if (walletdb && !walletdb->TxnCommit())
         return false;
 
     return true;
@@ -863,7 +890,8 @@ bool CWallet::GetAccountPubkey(CPubKey &pubKey, std::string strAccount, bool bFo
             return false;
 
         SetAddressBook(account.vchPubKey.GetID(), strAccount, "receive");
-        walletdb.WriteAccount(strAccount, account);
+        if (!IsShadowForkMemoryOnlyWallet())
+            walletdb.WriteAccount(strAccount, account);
     }
 
     pubKey = account.vchPubKey;
@@ -896,10 +924,11 @@ bool CWallet::MarkReplaced(const uint256& originalHash, const uint256& newHash)
 
     wtx.mapValue["replaced_by_txid"] = newHash.ToString();
 
-    CWalletDB walletdb(strWalletFile, "r+");
-
     bool success = true;
-    if (!walletdb.WriteTx(wtx)) {
+    if (IsShadowForkMemoryOnlyWallet()) {
+        LogPrintf("%s: shadow fork mode: marked wallet tx %s replaced in memory without wallet DB write\n",
+            __func__, wtx.GetHash().ToString());
+    } else if (!CWalletDB(strWalletFile, "r+").WriteTx(wtx)) {
         LogPrintf("%s: Updating walletdb tx %s failed", __func__, wtx.GetHash().ToString());
         success = false;
     }
@@ -1124,7 +1153,10 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
 {
     LOCK2(cs_main, cs_wallet);
 
-    CWalletDB walletdb(strWalletFile, "r+");
+    const bool fMemoryOnly = IsShadowForkMemoryOnlyWallet();
+    std::unique_ptr<CWalletDB> walletdb;
+    if (!fMemoryOnly)
+        walletdb.reset(new CWalletDB(strWalletFile, "r+"));
 
     std::set<uint256> todo;
     std::set<uint256> done;
@@ -1154,7 +1186,12 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
             wtx.nIndex = -1;
             wtx.setAbandoned();
             wtx.MarkDirty();
-            walletdb.WriteTx(wtx);
+            if (walletdb) {
+                walletdb->WriteTx(wtx);
+            } else {
+                LogPrintf("%s: shadow fork mode: marked wallet tx %s abandoned in memory without wallet DB write\n",
+                    __func__, wtx.GetHash().ToString());
+            }
             NotifyTransactionChanged(this, wtx.GetHash(), CT_UPDATED);
             // Iterate over all its outputs, and mark transactions in the wallet that spend them abandoned too
             TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(hashTx, 0));
@@ -1194,7 +1231,10 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
         return;
 
     // Do not flush the wallet here for performance reasons
-    CWalletDB walletdb(strWalletFile, "r+", false);
+    const bool fMemoryOnly = IsShadowForkMemoryOnlyWallet();
+    std::unique_ptr<CWalletDB> walletdb;
+    if (!fMemoryOnly)
+        walletdb.reset(new CWalletDB(strWalletFile, "r+", false));
 
     std::set<uint256> todo;
     std::set<uint256> done;
@@ -1214,7 +1254,12 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
             wtx.nIndex = -1;
             wtx.hashBlock = hashBlock;
             wtx.MarkDirty();
-            walletdb.WriteTx(wtx);
+            if (walletdb) {
+                walletdb->WriteTx(wtx);
+            } else {
+                LogPrintf("%s: shadow fork mode: marked wallet tx %s conflicted in memory without wallet DB write\n",
+                    __func__, wtx.GetHash().ToString());
+            }
             // Iterate over all its outputs, and mark transactions in the wallet that spend them conflicted too
             TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(now, 0));
             while (iter != mapTxSpends.end() && iter->first.hash == now) {
@@ -1446,7 +1491,7 @@ bool CWallet::SetHDMasterKey(const CPubKey& pubkey)
 bool CWallet::SetHDChain(const CHDChain& chain, bool memonly)
 {
     LOCK(cs_wallet);
-    if (!memonly && !CWalletDB(strWalletFile).WriteHDChain(chain))
+    if (!memonly && !IsShadowForkMemoryOnlyWallet() && !CWalletDB(strWalletFile).WriteHDChain(chain))
         throw runtime_error(std::string(__func__) + ": writing chain failed");
 
     hdChain = chain;
@@ -2908,14 +2953,17 @@ void CWallet::ListAccountCreditDebit(const std::string& strAccount, std::list<CA
 
 bool CWallet::AddAccountingEntry(const CAccountingEntry& acentry)
 {
-    CWalletDB walletdb(strWalletFile);
+    std::unique_ptr<CWalletDB> walletdb;
+    if (!IsShadowForkMemoryOnlyWallet())
+        walletdb.reset(new CWalletDB(strWalletFile));
 
-    return AddAccountingEntry(acentry, &walletdb);
+    return AddAccountingEntry(acentry, walletdb.get());
 }
 
 bool CWallet::AddAccountingEntry(const CAccountingEntry& acentry, CWalletDB *pwalletdb)
 {
-    if (!pwalletdb->WriteAccountingEntry_Backend(acentry))
+    if (!IsShadowForkMemoryOnlyWallet() &&
+        (!pwalletdb || !pwalletdb->WriteAccountingEntry_Backend(acentry)))
         return false;
 
     laccentries.push_back(acentry);
@@ -3101,7 +3149,7 @@ bool CWallet::DelAddressBook(const CTxDestination& address)
     {
         LOCK(cs_wallet); // mapAddressBook
 
-        if(fFileBacked)
+        if(fFileBacked && !IsShadowForkMemoryOnlyWallet())
         {
             // Delete destdata tuples associated with address
             std::string strAddress = CBitcoinAddress(address).ToString();
@@ -3115,6 +3163,8 @@ bool CWallet::DelAddressBook(const CTxDestination& address)
 
     NotifyAddressBookChanged(this, address, "", ::IsMine(*this, address) != ISMINE_NO, "", CT_DELETED);
 
+    if (IsShadowForkMemoryOnlyWallet())
+        return true;
     if (!fFileBacked)
         return false;
     CWalletDB(strWalletFile).ErasePurpose(CBitcoinAddress(address).ToString());
@@ -3123,7 +3173,7 @@ bool CWallet::DelAddressBook(const CTxDestination& address)
 
 bool CWallet::SetDefaultKey(const CPubKey &vchPubKey)
 {
-    if (fFileBacked)
+    if (fFileBacked && !IsShadowForkMemoryOnlyWallet())
     {
         if (!CWalletDB(strWalletFile).WriteDefaultKey(vchPubKey))
             return false;
@@ -3140,6 +3190,14 @@ bool CWallet::NewKeyPool()
 {
     {
         LOCK(cs_wallet);
+        if (IsShadowForkMemoryOnlyWallet()) {
+            setKeyPool.clear();
+            const bool locked = IsLocked();
+            LogPrintf("CWallet::NewKeyPool using on-demand memory-only keys%s\n",
+                locked ? " (wallet locked)" : "");
+            return true;
+        }
+
         CWalletDB walletdb(strWalletFile);
         BOOST_FOREACH(int64_t nIndex, setKeyPool)
             walletdb.ErasePool(nIndex);
@@ -3164,6 +3222,13 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
 {
     {
         LOCK(cs_wallet);
+
+        if (IsShadowForkMemoryOnlyWallet()) {
+            const bool locked = IsLocked();
+            LogPrintf("CWallet::TopUpKeyPool skipped for memory-only wallet%s\n",
+                locked ? " (wallet locked)" : "");
+            return true;
+        }
 
         if (IsLocked())
             return false;
@@ -3193,10 +3258,21 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
 
 void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
 {
-    nIndex = -1;
+    nIndex = KEYPOOL_INVALID_INDEX;
     keypool.vchPubKey = CPubKey();
     {
         LOCK(cs_wallet);
+
+        if (IsShadowForkMemoryOnlyWallet()) {
+            if (IsLocked()) {
+                LogPrintf("keypool reserve memory-only failed: wallet locked\n");
+                return;
+            }
+            keypool = CKeyPool(GenerateNewKey());
+            nIndex = KEYPOOL_MEMORY_ONLY_INDEX;
+            LogPrintf("keypool reserve memory-only\n");
+            return;
+        }
 
         if (!IsLocked())
             TopUpKeyPool();
@@ -3220,6 +3296,10 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
 
 void CWallet::KeepKey(int64_t nIndex)
 {
+    if (IsShadowForkMemoryOnlyWallet()) {
+        return;
+    }
+
     // Remove from key pool
     if (fFileBacked)
     {
@@ -3231,6 +3311,10 @@ void CWallet::KeepKey(int64_t nIndex)
 
 void CWallet::ReturnKey(int64_t nIndex)
 {
+    if (IsShadowForkMemoryOnlyWallet()) {
+        return;
+    }
+
     // Return to key pool
     {
         LOCK(cs_wallet);
@@ -3246,9 +3330,9 @@ bool CWallet::GetKeyFromPool(CPubKey& result)
     {
         LOCK(cs_wallet);
         ReserveKeyFromKeyPool(nIndex, keypool);
-        if (nIndex == -1)
+        if (nIndex == KEYPOOL_INVALID_INDEX)
         {
-            if (IsLocked()) return false;
+            if (IsLocked() || IsShadowForkMemoryOnlyWallet()) return false;
             result = GenerateNewKey();
             return true;
         }
@@ -3456,11 +3540,11 @@ std::set<CTxDestination> CWallet::GetAccountAddresses(const std::string& strAcco
 
 bool CReserveKey::GetReservedKey(CPubKey& pubkey)
 {
-    if (nIndex == -1)
+    if (nIndex == CWallet::KEYPOOL_INVALID_INDEX)
     {
         CKeyPool keypool;
         pwallet->ReserveKeyFromKeyPool(nIndex, keypool);
-        if (nIndex != -1)
+        if (nIndex != CWallet::KEYPOOL_INVALID_INDEX)
             vchPubKey = keypool.vchPubKey;
         else {
             return false;
@@ -3473,17 +3557,17 @@ bool CReserveKey::GetReservedKey(CPubKey& pubkey)
 
 void CReserveKey::KeepKey()
 {
-    if (nIndex != -1)
+    if (nIndex != CWallet::KEYPOOL_INVALID_INDEX)
         pwallet->KeepKey(nIndex);
-    nIndex = -1;
+    nIndex = CWallet::KEYPOOL_INVALID_INDEX;
     vchPubKey = CPubKey();
 }
 
 void CReserveKey::ReturnKey()
 {
-    if (nIndex != -1)
+    if (nIndex != CWallet::KEYPOOL_INVALID_INDEX)
         pwallet->ReturnKey(nIndex);
-    nIndex = -1;
+    nIndex = CWallet::KEYPOOL_INVALID_INDEX;
     vchPubKey = CPubKey();
 }
 
@@ -3659,7 +3743,7 @@ bool CWallet::AddDestData(const CTxDestination &dest, const std::string &key, co
         return false;
 
     mapAddressBook[dest].destdata.insert(std::make_pair(key, value));
-    if (!fFileBacked)
+    if (!fFileBacked || IsShadowForkMemoryOnlyWallet())
         return true;
     return CWalletDB(strWalletFile).WriteDestData(CBitcoinAddress(dest).ToString(), key, value);
 }
@@ -3668,7 +3752,7 @@ bool CWallet::EraseDestData(const CTxDestination &dest, const std::string &key)
 {
     if (!mapAddressBook[dest].destdata.erase(key))
         return false;
-    if (!fFileBacked)
+    if (!fFileBacked || IsShadowForkMemoryOnlyWallet())
         return true;
     return CWalletDB(strWalletFile).EraseDestData(CBitcoinAddress(dest).ToString(), key);
 }
@@ -3927,7 +4011,8 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
                     copyTo->fFromMe = copyFrom->fFromMe;
                     copyTo->strFromAccount = copyFrom->strFromAccount;
                     copyTo->nOrderPos = copyFrom->nOrderPos;
-                    walletdb.WriteTx(*copyTo);
+                    if (!walletInstance->IsShadowForkMemoryOnly())
+                        walletdb.WriteTx(*copyTo);
                 }
             }
         }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -623,6 +623,10 @@ public:
             mapKeyMetadata[keyid] = CKeyMetadata(keypool.nTime);
     }
 
+    /** Special keypool indexes returned through ReserveKeyFromKeyPool. */
+    static const int64_t KEYPOOL_INVALID_INDEX = -1;
+    static const int64_t KEYPOOL_MEMORY_ONLY_INDEX = -2;
+
     // Map from Key ID (for regular keys) or Script ID (for watch-only keys) to
     // key metadata.
     std::map<CTxDestination, CKeyMetadata> mapKeyMetadata;
@@ -741,6 +745,7 @@ public:
     //! Adds a watch-only address to the store, without saving it to disk (used by LoadWallet)
     bool LoadWatchOnly(const CScript &dest);
 
+    bool IsShadowForkMemoryOnly() const;
     bool Unlock(const SecureString& strWalletPassphrase);
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
@@ -983,7 +988,7 @@ protected:
 public:
     CReserveKey(CWallet* pwalletIn)
     {
-        nIndex = -1;
+        nIndex = CWallet::KEYPOOL_INVALID_INDEX;
         pwallet = pwalletIn;
     }
 


### PR DESCRIPTION
## Summary

Adds a default-off trusted startup-cut mode for isolated shadowfork prepared-volume runtimes.

Normal `-shadowforkstartupcut` still uses undo replay through `DisconnectTip`, preserving the historical fork-height chainstate. The new `-shadowforktruststartupcut=1` path is an explicit escape hatch for prepared volumes where startup latency matters and the inherited UTXO contents are accepted as a synthetic test state.

## Changes

- Adds `-shadowforktruststartupcut` with init-time validation.
- Keeps the trusted path shadowfork-only and dependent on `-shadowforkstartupcut`.
- Refuses trusted cuts unless the coins best marker matches either the loaded source tip or the requested cut target.
- Clears inherited mempool state, clamps lazy active-chain metadata, clears inherited best-chain candidates, and removes loaded above-cut block-index entries after the trusted cut.
- Tightens `-shadowforkmemoryonlywallet` so HD/default-key/keypool writes do not touch wallet DB and memory-only keys are generated on demand.

## Safety Notes

This is not a historical rollback. With `-shadowforktruststartupcut=1`, the node trusts the prepared-volume UTXO contents and only moves the visible chainstate marker to the requested cut height. It should be used only for isolated shadowfork test runtimes that bootstrap or spend post-fork outputs.

## Validation

- `git diff --check`
- Built amd64 Docker runtime image:
  - `vladogeos/dogecoin-shadow-runtime:pr10-trusted-cut-local`
- Smoke checked the image with `dogecoind --version`.

## Stack

Targets current `feat/shadow`, which already contains #8 and #9.
