### PR TITLE
fix: support regtest shadowfork snapshot validation

### DIFF
--- a/doc/README_osx.md
+++ b/doc/README_osx.md
@@ -35,6 +35,14 @@ needed:
 Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk
 ```
 
+Compatibility note for future agents: the deterministic macOS build uses this
+older `MacOSX10.11.sdk`, so do not assume headers from newer native macOS SDKs
+exist in CI. In particular, keep `src/crypto/scrypt.{h,cpp}` on its
+scrypt-private endian helpers instead of adding `__APPLE__` guards that include
+`<sys/endian.h>` or depending on generic `le32dec`/`le32enc` names. When
+changing platform guards, verify both a native macOS compile and the
+deterministic/cross-build SDK path.
+
 Unfortunately, the usual linux tools (7zip, hpmount, loopback mount) are incapable of opening this file.
 To create a tarball suitable for Gitian input, there are two options:
 

--- a/src/crypto/scrypt-sse2.cpp
+++ b/src/crypto/scrypt-sse2.cpp
@@ -111,7 +111,7 @@ void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchp
 
 	for (k = 0; k < 2; k++) {
 		for (i = 0; i < 16; i++) {
-			X.u32[k * 16 + i] = le32dec(&B[(k * 16 + (i * 5 % 16)) * 4]);
+			X.u32[k * 16 + i] = scrypt_le32dec(&B[(k * 16 + (i * 5 % 16)) * 4]);
 		}
 	}
 
@@ -131,7 +131,7 @@ void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchp
 
 	for (k = 0; k < 2; k++) {
 		for (i = 0; i < 16; i++) {
-			le32enc(&B[(k * 16 + (i * 5 % 16)) * 4], X.u32[k * 16 + i]);
+			scrypt_le32enc(&B[(k * 16 + (i * 5 % 16)) * 4], X.u32[k * 16 + i]);
 		}
 	}
 

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -43,17 +43,8 @@
 #endif
 #endif
 
-#if defined(__APPLE__)
-/* macOS SDK 26+ provides be32dec/be32enc via sys/endian.h (already included from scrypt.h) */
-#elif !defined(__FreeBSD__)
-static inline uint32_t be32dec(const void *pp)
-{
-	const uint8_t *p = (uint8_t const *)pp;
-	return ((uint32_t)(p[3]) + ((uint32_t)(p[2]) << 8) +
-	    ((uint32_t)(p[1]) << 16) + ((uint32_t)(p[0]) << 24));
-}
-
-static inline void be32enc(void *pp, uint32_t x)
+/* Use a private helper name; see scrypt.h for the macOS SDK compatibility note. */
+static inline void scrypt_be32enc(void *pp, uint32_t x)
 {
 	uint8_t *p = (uint8_t *)pp;
 	p[3] = x & 0xff;
@@ -62,7 +53,6 @@ static inline void be32enc(void *pp, uint32_t x)
 	p[0] = (x >> 24) & 0xff;
 }
 
-#endif
 /**
  * PBKDF2_SHA256(passwd, passwdlen, salt, saltlen, c, buf, dkLen):
  * Compute PBKDF2(passwd, salt, c, dkLen) using HMAC-SHA256 as the PRF, and
@@ -89,7 +79,7 @@ PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
 	/* Iterate through the blocks. */
 	for (i = 0; i * 32 < dkLen; i++) {
 		/* Generate INT(i + 1). */
-		be32enc(ivec, (uint32_t)(i + 1));
+		scrypt_be32enc(ivec, (uint32_t)(i + 1));
 
 		/* Compute U_1 = PRF(P, S || INT(i)). */
 		PShctx.Copy(&hctx);
@@ -198,7 +188,7 @@ void scrypt_1024_1_1_256_sp_generic(const char *input, char *output, char *scrat
 	PBKDF2_SHA256((const uint8_t *)input, 80, (const uint8_t *)input, 80, 1, B, 128);
 
 	for (k = 0; k < 32; k++)
-		X[k] = le32dec(&B[4 * k]);
+		X[k] = scrypt_le32dec(&B[4 * k]);
 
 	for (i = 0; i < 1024; i++) {
 		memcpy(&V[i * 32], X, 128);
@@ -214,7 +204,7 @@ void scrypt_1024_1_1_256_sp_generic(const char *input, char *output, char *scrat
 	}
 
 	for (k = 0; k < 32; k++)
-		le32enc(&B[4 * k], X[k]);
+		scrypt_le32enc(&B[4 * k], X[k]);
 
 	PBKDF2_SHA256((const uint8_t *)input, 80, B, 128, 1, (uint8_t *)output, 32);
 }

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -43,7 +43,9 @@
 #endif
 #endif
 
-#if !defined(__FreeBSD__)
+#if defined(__APPLE__)
+/* macOS SDK 26+ provides be32dec/be32enc via sys/endian.h (already included from scrypt.h) */
+#elif !defined(__FreeBSD__)
 static inline uint32_t be32dec(const void *pp)
 {
 	const uint8_t *p = (uint8_t const *)pp;

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -36,17 +36,19 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
-#if defined(__APPLE__)
-#include <sys/endian.h>
-#elif !defined(__FreeBSD__)
-static inline uint32_t le32dec(const void *pp)
+/*
+ * Use scrypt-private helper names instead of le32dec/le32enc. Newer macOS SDKs
+ * may define the generic names indirectly through <sys/endian.h>, while the
+ * deterministic macOS CI SDK is too old to include that header directly.
+ */
+static inline uint32_t scrypt_le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;
         return ((uint32_t)(p[0]) + ((uint32_t)(p[1]) << 8) +
             ((uint32_t)(p[2]) << 16) + ((uint32_t)(p[3]) << 24));
 }
 
-static inline void le32enc(void *pp, uint32_t x)
+static inline void scrypt_le32enc(void *pp, uint32_t x)
 {
         uint8_t *p = (uint8_t *)pp;
         p[0] = x & 0xff;
@@ -54,5 +56,4 @@ static inline void le32enc(void *pp, uint32_t x)
         p[2] = (x >> 16) & 0xff;
         p[3] = (x >> 24) & 0xff;
 }
-#endif
 #endif // BITCOIN_CRYPTO_SCRYPT_H

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -36,7 +36,9 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
-#if !defined(__FreeBSD__)
+#if defined(__APPLE__)
+#include <sys/endian.h>
+#elif !defined(__FreeBSD__)
 static inline uint32_t le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -476,7 +476,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageGroup(_("Shadow fork options (dev/testing):"));
         strUsage += HelpMessageOpt("-buildshadowforksnapshot", _("Build or refresh the global shadow fork block-index snapshot from the current source datadir and exit"));
         strUsage += HelpMessageOpt("-shadowfork=<height>", _("Enable shadow fork mode, forking from the specified block height"));
-        strUsage += HelpMessageOpt("-shadowforkchain=<chain>", _("Source chain to fork from: main or test (default: main)"));
+        strUsage += HelpMessageOpt("-shadowforkchain=<chain>", _("Source chain to fork from: main, test, or regtest (default: main)"));
         strUsage += HelpMessageOpt("-shadowforkmaturity=<n>", strprintf(_("Coinbase maturity for shadow fork (default: %d)"), 1));
         strUsage += HelpMessageOpt("-shadowforkfastblockindexcandidates", _("In shadow fork mode, populate block index candidates from the active tip only during startup (default: 1)"));
         strUsage += HelpMessageOpt("-shadowforkdeferchainstateflush", _("In shadow fork mode, defer automatic IF_NEEDED/PERIODIC chainstate flushes; clean shutdown still flushes (default: 1)"));
@@ -918,12 +918,12 @@ bool AppInitParameterInteraction()
 
     if (GetBoolArg("-buildshadowforksnapshot", false)) {
         if (chainparams.GetConsensus(0).fShadowForkMode) {
-            return InitError(_("Shadow fork snapshots must be built from a source main/test datadir, not from a shadow fork datadir."));
+            return InitError(_("Shadow fork snapshots must be built from a source main/test/regtest datadir, not from a shadow fork datadir."));
         }
 
         const std::string network_id = chainparams.NetworkIDString();
-        if (network_id != "main" && network_id != "test") {
-            return InitError(_("Shadow fork snapshots can only be built from main or test source datadirs."));
+        if (network_id != "main" && network_id != "test" && network_id != "regtest") {
+            return InitError(_("Shadow fork snapshots can only be built from main, test, or regtest source datadirs."));
         }
 
         if (GetBoolArg("-reindex", false) || GetBoolArg("-reindex-chainstate", false)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3318,7 +3318,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const CB
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness nonce). In case there are
     //   multiple, the last one is used.
     bool fHaveWitness = false;
-    if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (IsWitnessEnabled(pindexPrev, consensusParams)) {
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != -1) {
             bool malleated = false;
@@ -5051,14 +5051,14 @@ bool BuildShadowForkBlockIndexSnapshot(const CChainParams& chainparams)
     LOCK(cs_main);
 
     if (chainparams.GetConsensus(0).fShadowForkMode) {
-        return error("%s: shadowfork snapshots must be built from a source main/test datadir", __func__);
+        return error("%s: shadowfork snapshots must be built from a source main/test/regtest datadir", __func__);
     }
     if (chainActive.Tip() == NULL) {
         return error("%s: chainActive tip is null", __func__);
     }
 
     const std::string source_chain = GetShadowForkSnapshotSourceChain(chainparams);
-    if (source_chain != "main" && source_chain != "test") {
+    if (source_chain != "main" && source_chain != "test" && source_chain != "regtest") {
         return error("%s: unsupported shadowfork snapshot source chain %s", __func__, source_chain);
     }
 


### PR DESCRIPTION
## Summary
- allow shadowfork block-index snapshots to be built from regtest datadirs for local artificial-DB validation
- route witness commitment validation through Dogecoin's IsWitnessEnabled helper so regtest shadowfork forward imports do not reject Dogecoin-mined blocks with disabled SegWit
- keep macOS SDK 26 builds working by using system endian helpers on Apple platforms

## Validation
- ./configure --without-gui --disable-wallet --disable-tests --disable-bench --disable-zmq --with-miniupnpc=no --with-boost=/opt/homebrew/opt/boost --with-openssl=/opt/homebrew/opt/openssl@3 LDFLAGS='-L/opt/homebrew/opt/libevent/lib' CPPFLAGS='-I/opt/homebrew/opt/libevent/include'
- make -C src -j"10" dogecoind dogecoin-cli
- DOGECOIND=/Users/vmark/work/DogeOS69/worktrees/dogecoin-shadowfork-trusted-startup-cut/src/dogecoind /Users/vmark/work/DogeOS69/dogecoin-shadow-orchestrator/scripts/shadowfork_prepared_regtest_integration.sh --timeout 120
